### PR TITLE
Fix introspection being misaligned when return values are specified

### DIFF
--- a/tools/code-generator.cpp
+++ b/tools/code-generator.cpp
@@ -193,7 +193,7 @@ void CodeGenerator::start_element( std::string tagName, std::map<std::string,std
             .setPureVirtual( true );
     } else if( tagName.compare( "arg" ) == 0 ){
         cppgenerate::Argument arg;
-        ///TODO: Signals should be assumed to have outwards direction.
+
         if( tagAttrs.find( "direction" ) == tagAttrs.end() ){
             //XML_GetCurrentLineNumber
             std::cerr << "WARNING: No direction for arg found(assuming in)." << std::endl;
@@ -286,7 +286,6 @@ void CodeGenerator::end_element( std::string tagName ){
                       "sigc::mem_fun( adaptee, &" + m_adapteeClasses.data()[ m_adapteeClasses.size() - 1 ].getName() +
                       "::" + m_currentAdapteeMethod.name() + " ) );" ) );
 
-	///TODO: If method has return values, we must specify the arg names for the return types before the inputs
         //Set the names for the return values/arguments
         if(m_currentProxyMethod.returnType() != "void") {
             m_currentAdapterConstructor.addCode( cppgenerate::CodeBlock::create()

--- a/tools/code-generator.cpp
+++ b/tools/code-generator.cpp
@@ -193,7 +193,7 @@ void CodeGenerator::start_element( std::string tagName, std::map<std::string,std
             .setPureVirtual( true );
     }else if( tagName.compare( "arg" ) == 0 ){
         cppgenerate::Argument arg;
-
+	///TODO: Signals should be assumed to have outwards direction.
         if( tagAttrs.find( "direction" ) == tagAttrs.end() ){
             //XML_GetCurrentLineNumber
             std::cerr << "WARNING: No direction for arg found(assuming in)." << std::endl;
@@ -285,6 +285,8 @@ void CodeGenerator::end_element( std::string tagName ){
                       m_currentAdapteeMethod.name() + "\"," +
                       "sigc::mem_fun( adaptee, &" + m_adapteeClasses.data()[ m_adapteeClasses.size() - 1 ].getName() +
                       "::" + m_currentAdapteeMethod.name() + " ) );" ) );
+
+	///TODO: If method has return values, we must specify the arg names for the return types before the inputs
         for( cppgenerate::Argument arg : args ){
             m_currentAdapterConstructor.addCode( cppgenerate::CodeBlock::create()
                 .addLine( "temp_method->set_arg_name( " + std::to_string( argNum ) + ", \"" + arg.name() + "\" );" ) );

--- a/tools/code-generator.cpp
+++ b/tools/code-generator.cpp
@@ -66,8 +66,8 @@ void CodeGenerator::start_element( std::string tagName, std::map<std::string,std
         if( tagAttrs.find( "dest" ) != tagAttrs.end() ){
             dest = "\"" + tagAttrs[ "dest" ] + "\"";
         }else{
-            std::cerr << "WARNING: Did not find 'dest' in XML for node \'" 
-                      << tagName << "\'.  Line:" 
+            std::cerr << "WARNING: Did not find 'dest' in XML for node \'"
+                      << tagName << "\'.  Line:"
                       << XML_GetCurrentLineNumber( m_parser )
                       << std::endl;
         }
@@ -76,7 +76,7 @@ void CodeGenerator::start_element( std::string tagName, std::map<std::string,std
             path = "\"" + tagAttrs[ "path" ] + "\"";
         }else{
             std::cerr << "WARNING: Did not find 'path' in xml for node \'"
-                      << tagName << "\'.  Line:" 
+                      << tagName << "\'.  Line:"
                       << XML_GetCurrentLineNumber( m_parser )
                       << std::endl;
         }
@@ -131,7 +131,7 @@ void CodeGenerator::start_element( std::string tagName, std::map<std::string,std
               .setType( "std::string" )
               .setName( "path" )
               .setDefaultValue( path ) );
-              
+
         m_proxyClasses.push_back( newclass );
 
         /* Add new adapter class */
@@ -191,9 +191,9 @@ void CodeGenerator::start_element( std::string tagName, std::map<std::string,std
             .setName( tagAttrs[ "name" ] )
             .setAccessModifier( cppgenerate::AccessModifier::PUBLIC )
             .setPureVirtual( true );
-    }else if( tagName.compare( "arg" ) == 0 ){
+    } else if( tagName.compare( "arg" ) == 0 ){
         cppgenerate::Argument arg;
-	///TODO: Signals should be assumed to have outwards direction.
+        ///TODO: Signals should be assumed to have outwards direction.
         if( tagAttrs.find( "direction" ) == tagAttrs.end() ){
             //XML_GetCurrentLineNumber
             std::cerr << "WARNING: No direction for arg found(assuming in)." << std::endl;
@@ -270,8 +270,8 @@ void CodeGenerator::end_element( std::string tagName ){
             .addMemberVariable( memberVar );
 
         m_currentProxyConstructor.addCode( cppgenerate::CodeBlock::create()
-            .addLine( "m_method_" + m_currentProxyMethod.name() + 
-                      " = this->create_method" + methodProxyType + 
+            .addLine( "m_method_" + m_currentProxyMethod.name() +
+                      " = this->create_method" + methodProxyType +
                       "(\"" + m_currentInterface + "\",\"" + m_currentProxyMethod.name() + "\");" ) );
 
         /* Add our new virtual method that needs to be implemented to our adaptee */
@@ -280,13 +280,21 @@ void CodeGenerator::end_element( std::string tagName ){
 
         /* Add our internal construction of the adaptee method */
         m_currentAdapterConstructor.addCode( cppgenerate::CodeBlock::create()
-            .addLine( "temp_method = this->create_method" + methodProxyType + 
-                      "( \"" + m_currentInterface + "\", \"" + 
+            .addLine( "temp_method = this->create_method" + methodProxyType +
+                      "( \"" + m_currentInterface + "\", \"" +
                       m_currentAdapteeMethod.name() + "\"," +
                       "sigc::mem_fun( adaptee, &" + m_adapteeClasses.data()[ m_adapteeClasses.size() - 1 ].getName() +
                       "::" + m_currentAdapteeMethod.name() + " ) );" ) );
 
 	///TODO: If method has return values, we must specify the arg names for the return types before the inputs
+        //Set the names for the return values/arguments
+        if(m_currentProxyMethod.returnType() != "void") {
+            m_currentAdapterConstructor.addCode( cppgenerate::CodeBlock::create()
+                .addLine( "temp_method->set_arg_name( " + std::to_string( argNum ) + ", \"" + "return_value" + "\" );" ) );
+            argNum++;
+        }
+
+        //Now set the names for the input arguments
         for( cppgenerate::Argument arg : args ){
             m_currentAdapterConstructor.addCode( cppgenerate::CodeBlock::create()
                 .addLine( "temp_method->set_arg_name( " + std::to_string( argNum ) + ", \"" + arg.name() + "\" );" ) );


### PR DESCRIPTION
Currently xml2cpp does not name args with the "out" direction, which results in the output arg being named as the first input argument, throwing the naming of the rest of the input arguments off by 1 position.

This is apparent when viewing your connected adapter with `dbus-cxx-introspect` or `d-feet`.

I do see that multiple return values are currently unsupported, so as long as there will ever only be one return value, then we only need to name one return value argument.