### PR TITLE
Add default cases to switch statements

### DIFF
--- a/dbus-cxx/methodbase.cpp
+++ b/dbus-cxx/methodbase.cpp
@@ -60,5 +60,18 @@ namespace DBus
     return m_signal_name_changed;
   }
 
+  std::string MethodBase::introspect(int space_depth) const
+  {
+    return std::string();
+  }
+
+  std::string MethodBase::arg_name(size_t i)
+  {
+   return std::string();
+  }
+
+  void MethodBase::set_arg_name(size_t i, const std::string& name)
+  {
+  }
 }
 

--- a/dbus-cxx/methodbase.h
+++ b/dbus-cxx/methodbase.h
@@ -65,11 +65,11 @@ namespace DBus
       sigc::signal<void,const std::string&/*old name*/, const std::string&/*new name*/> signal_name_changed();
 
       /** Returns a DBus XML description of this interface */
-      virtual std::string introspect(int space_depth=0) const { return std::string(); }
+      virtual std::string introspect(int space_depth=0) const;
 
-      virtual std::string arg_name(size_t i) { return std::string(); }
+      virtual std::string arg_name(size_t i);
 
-      virtual void set_arg_name(size_t i, const std::string& name) { }
+      virtual void set_arg_name(size_t i, const std::string& name);
 
     protected:
 

--- a/dbus-cxx/signal_base.cpp
+++ b/dbus-cxx/signal_base.cpp
@@ -126,6 +126,20 @@ namespace DBus
     m_destination = s;
   }
 
+  std::string signal_base::introspect(int space_depth) const
+  {
+    return std::string();
+  }
+
+  std::string signal_base::arg_name(size_t i)
+  {
+    return std::string();
+  }
+
+  void signal_base::set_arg_name(size_t i, const std::string& name)
+  {
+  }
+
   bool signal_base::handle_dbus_outgoing(Message::const_pointer msg)
   {
     Connection::pointer conn = m_connection.lock();

--- a/dbus-cxx/signal_base.h
+++ b/dbus-cxx/signal_base.h
@@ -96,11 +96,11 @@ namespace DBus
       virtual pointer clone() = 0;
 
       /** Returns a DBus XML description of this interface */
-      virtual std::string introspect(int space_depth=0) const { return std::string(); }
+      virtual std::string introspect(int space_depth=0) const; 
 
-      virtual std::string arg_name(size_t i) { return std::string(); }
+      virtual std::string arg_name(size_t i);
 
-      virtual void set_arg_name(size_t i, const std::string& name) { }
+      virtual void set_arg_name(size_t i, const std::string& name);
 
     protected:
 

--- a/dbus-cxx/types.h
+++ b/dbus-cxx/types.h
@@ -185,8 +185,9 @@ template <class T>
         return "vector";
       case TYPE_DICT_ENTRY:
         return "map";
+      default:
+	return "";
     }
-    return std::string("");
   }
 
   inline bool type_is_templated( DBus::Type t ){
@@ -196,8 +197,9 @@ template <class T>
           return true;
         case TYPE_DICT_ENTRY:
           return true;
+	default:
+	  return false;
     }
-    return false;
   }
 
   inline

--- a/dbus-cxx/types.h
+++ b/dbus-cxx/types.h
@@ -186,7 +186,7 @@ template <class T>
       case TYPE_DICT_ENTRY:
         return "map";
       default:
-	return "";
+        return "";
     }
   }
 
@@ -198,7 +198,7 @@ template <class T>
         case TYPE_DICT_ENTRY:
           return true;
 	default:
-	  return false;
+          return false;
     }
   }
 

--- a/dbus-cxx/types.h
+++ b/dbus-cxx/types.h
@@ -197,7 +197,7 @@ template <class T>
           return true;
         case TYPE_DICT_ENTRY:
           return true;
-	default:
+        default:
           return false;
     }
   }


### PR DESCRIPTION
The simplest client file, when compiling with `-Wall -Wextra`, results in a ton of unneeded warnings.

The test script I used:

```
#!/bin/bash

# build the package
(
  mkdir build
  cd build
  cmake ..
  make package
  tar -xzf dbus-cxx-0.1.1-Linux.tar.gz
)

# use the package
cat <<EOF > compile.cpp
#include <dbus-cxx.h>
#include <dbus-cxx/signal_base.h>
#include <dbus-cxx/dbus_signal.h>
int main() {}
EOF

export PKG_CONFIG_PATH=build/dbus-cxx-0.1.1-Linux/lib/pkgconfig:/usr/lib/x86_64-linux-gnu/pkgconfig

pkgconf -cflags dbus-cxx-1.0 dbus-1
export CXXFLAGS=$(pkgconf -cflags dbus-cxx-1.0 dbus-1) 

g++ -Wall -Wextra -Werror $CXXFLAGS -I build/dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11 compile.cpp
```

```
g++ -Wall $CXXFLAGS -I dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11 ../compile.cpp 
/home/krpi/dbus-cxx/dbus-cxx/methodbase.cpp:63:57: error: default argument given for parameter 1 of ‘std::__cxx11::string DBus::MethodBase::introspect(int) const’ [-fpermissive]
   std::string MethodBase::introspect(int space_depth=0) const
                                                         ^~~~~
In file included from /home/krpi/dbus-cxx/dbus-cxx/methodbase.cpp:20:0:
/home/krpi/dbus-cxx/dbus-cxx/methodbase.h:68:27: note: previous specification in ‘virtual std::__cxx11::string DBus::MethodBase::introspect(int) const’ here
       virtual std::string introspect(int space_depth=0) const;
                           ^~~~~~~~~~
CMakeFiles/dbus-cxx.dir/build.make:350: recipe for target 'CMakeFiles/dbus-cxx.dir/dbus-cxx/methodbase.cpp.o' failed
make[2]: *** [CMakeFiles/dbus-cxx.dir/dbus-cxx/methodbase.cpp.o] Error 1
CMakeFiles/Makefile2:109: recipe for target 'CMakeFiles/dbus-cxx.dir/all' failed
make[1]: *** [CMakeFiles/dbus-cxx.dir/all] Error 2
Makefile:151: recipe for target 'all' failed
make: *** [all] Error 2
-I/usr/local/include/dbus-cxx-0.11 -I/usr/include/dbus-1.0 -I/usr/lib/x86_64-linux-gnu/dbus-1.0/include -I/usr/include/sigc++-2.0 -I/usr/lib/x86_64-linux-gnu/sigc++-2.0/include  
In file included from build/dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/interface.h:30:0,
                 from build/dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/object.h:705,
                 from build/dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/connection.h:33,
                 from build/dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx.h:29,
                 from compile.cpp:1:
build/dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/methodbase.h: In member function ‘virtual std::__cxx11::string DBus::MethodBase::introspect(int) const’:
build/dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/methodbase.h:68:54: error: unused parameter ‘space_depth’ [-Werror=unused-parameter]
       virtual std::string introspect(int space_depth=0) const { return std::string(); }
                                                      ^
build/dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/methodbase.h: In member function ‘virtual std::__cxx11::string DBus::MethodBase::arg_name(size_t)’:
build/dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/methodbase.h:70:43: error: unused parameter ‘i’ [-Werror=unused-parameter]
       virtual std::string arg_name(size_t i) { return std::string(); }
                                           ^
build/dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/methodbase.h: In member function ‘virtual void DBus::MethodBase::set_arg_name(size_t, const string&)’:
build/dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/methodbase.h:72:40: error: unused parameter ‘i’ [-Werror=unused-parameter]
       virtual void set_arg_name(size_t i, const std::string& name) { }
                                        ^
build/dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/methodbase.h:72:62: error: unused parameter ‘name’ [-Werror=unused-parameter]
       virtual void set_arg_name(size_t i, const std::string& name) { }


In file included from dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/messageiterator.h:20:0,
                 from dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/message.h:26,
                 from dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/callmessage.h:19,
                 from dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx.h:28,
                 from ../compile.cpp:1:
dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/types.h: In function ‘std::__cxx11::string DBus::include_file_for_type(DBus::Type)’:
dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/types.h:172:12: warning: enumeration value ‘TYPE_INVALID’ not handled in switch [-Wswitch]
     switch ( t )
            ^
dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/types.h:172:12: warning: enumeration value ‘TYPE_BOOLEAN’ not handled in switch [-Wswitch]
dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/types.h:172:12: warning: enumeration value ‘TYPE_DOUBLE’ not handled in switch [-Wswitch]
dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/types.h:172:12: warning: enumeration value ‘TYPE_OBJECT_PATH’ not handled in switch [-Wswitch]
dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/types.h:172:12: warning: enumeration value ‘TYPE_SIGNATURE’ not handled in switch [-Wswitch]
dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/types.h:172:12: warning: enumeration value ‘TYPE_VARIANT’ not handled in switch [-Wswitch]
dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/types.h:172:12: warning: enumeration value ‘TYPE_STRUCT’ not handled in switch [-Wswitch]
dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/types.h:172:12: warning: enumeration value ‘TYPE_UNIX_FD’ not handled in switch [-Wswitch]
dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/types.h: In function ‘bool DBus::type_is_templated(DBus::Type)’:
dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/types.h:193:11: warning: enumeration value ‘TYPE_INVALID’ not handled in switch [-Wswitch]
     switch( t )
           ^
dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/types.h:193:11: warning: enumeration value ‘TYPE_BYTE’ not handled in switch [-Wswitch]
dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/types.h:193:11: warning: enumeration value ‘TYPE_BOOLEAN’ not handled in switch [-Wswitch]
dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/types.h:193:11: warning: enumeration value ‘TYPE_INT16’ not handled in switch [-Wswitch]
dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/types.h:193:11: warning: enumeration value ‘TYPE_UINT16’ not handled in switch [-Wswitch]
dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/types.h:193:11: warning: enumeration value ‘TYPE_INT32’ not handled in switch [-Wswitch]
dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/types.h:193:11: warning: enumeration value ‘TYPE_UINT32’ not handled in switch [-Wswitch]
dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/types.h:193:11: warning: enumeration value ‘TYPE_INT64’ not handled in switch [-Wswitch]
dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/types.h:193:11: warning: enumeration value ‘TYPE_UINT64’ not handled in switch [-Wswitch]
dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/types.h:193:11: warning: enumeration value ‘TYPE_DOUBLE’ not handled in switch [-Wswitch]
dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/types.h:193:11: warning: enumeration value ‘TYPE_STRING’ not handled in switch [-Wswitch]
dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/types.h:193:11: warning: enumeration value ‘TYPE_OBJECT_PATH’ not handled in switch [-Wswitch]
dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/types.h:193:11: warning: enumeration value ‘TYPE_SIGNATURE’ not handled in switch [-Wswitch]
dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/types.h:193:11: warning: enumeration value ‘TYPE_VARIANT’ not handled in switch [-Wswitch]
dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/types.h:193:11: warning: enumeration value ‘TYPE_STRUCT’ not handled in switch [-Wswitch]
dbus-cxx-0.1.1-Linux/include/dbus-cxx-0.11/dbus-cxx/types.h:193:11: warning: enumeration value ‘TYPE_UNIX_FD’ not handled in switch [-Wswitch]
```
