### PR TITLE
Remove 'dbus-cxx-private.h' from public headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,6 @@ set( DBUS_CXX_HEADERS1
 set( DBUS_CXX_HEADERS
     dbus-cxx/accumulators.h
     dbus-cxx/callmessage.h
-    dbus-cxx/dbus-cxx-private.h
     dbus-cxx/dispatcher.h
     dbus-cxx/enums.h
     dbus-cxx/error.h


### PR DESCRIPTION
I don't believe `dbus-cxx-private.h` is used from any of the public headers.