### PR TITLE
Include typeinfo for typeid()

### DIFF
--- a/dbus-cxx/demangle.h
+++ b/dbus-cxx/demangle.h
@@ -21,6 +21,7 @@
 #define DBUSCXX_DEMANGLE_H
 
 #include <string>
+#include <typeinfo>
 #include <dbus-cxx/dbus-cxx-config.h>
 
 #if DBUS_CXX_HAS_CXXABI_H


### PR DESCRIPTION
Otherwise fails with:
    error: must '#include <typeinfo>' before using 'typeid'

FYI: I've been using GCC 11.2.