### PR TITLE
cmake: improve include paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -207,9 +207,7 @@ set( DBUS_CXX_HEADERS
 
 set( DBUS_CXX_INCLUDE_DIRECTORIES 
     ${PROJECT_SOURCE_DIR} 
-    ${PROJECT_SOURCE_DIR}/dbus-cxx
-    ${PROJECT_BINARY_DIR}
-    ${PROJECT_BINARY_DIR}/dbus-cxx )
+    ${PROJECT_BINARY_DIR} )
 include_directories( ${DBUS_CXX_INCLUDE_DIRECTORIES} 
     ${dbus_INCLUDE_DIRS} 
     ${sigc_INCLUDE_DIRS} )

--- a/dbus-cxx/matchrule.h
+++ b/dbus-cxx/matchrule.h
@@ -20,7 +20,7 @@
 #define DBUSCXX_MATCH_RULE_H
 
 #include <memory>
-#include "dbus-cxx-config.h"
+#include <dbus-cxx/dbus-cxx-config.h>
 
 namespace DBus {
 

--- a/dbus-cxx/sasl.h
+++ b/dbus-cxx/sasl.h
@@ -19,7 +19,7 @@
 #ifndef DBUSCXX_SASL_H
 #define DBUSCXX_SASL_H
 
-#include <dbus-cxx-config.h>
+#include <dbus-cxx/dbus-cxx-config.h>
 
 #include <memory>
 #include <stdint.h>

--- a/dbus-cxx/sendmsgtransport.cpp
+++ b/dbus-cxx/sendmsgtransport.cpp
@@ -21,8 +21,8 @@
 #include "dbus-cxx-private.h"
 #include "utility.h"
 #include "validator.h"
+#include "message.h"
 
-#include <message.h>
 #include <string.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/dbus-cxx/simpletransport.cpp
+++ b/dbus-cxx/simpletransport.cpp
@@ -18,7 +18,7 @@
  ***************************************************************************/
 #include "simpletransport.h"
 
-#include <dbus-cxx-private.h>
+#include "dbus-cxx-private.h"
 #include "demarshaling.h"
 #include "message.h"
 #include "utility.h"


### PR DESCRIPTION
I'm currently trying to integrate dbus-cxx into [buildroot](https://buildroot.org).

When compiling with gcc 10 I ran into the following issue:

```
dbus-cxx 2.1.0 Configuring
(mkdir -p /home/d.lang/br-test-pkg/bootlin-armv5-uclibc/build/dbus-cxx-2.1.0/ && cd /home/d.lang/br-test-pkg/bootlin-armv5-uclibc/build/dbus-cxx-2.1.0/ && rm -f CMakeCache.txt && PATH="/home/d.lang/br-test-pkg/bootlin-armv5-uclibc/host/bin:/home/d.lang/br-test-pkg/bootlin-armv5-uclibc/host/sbin:/home/d.lang/.nvm/versions/node/v15.6.0/bin:/opt/doxygen/bin:/home/d.lang/bin:/usr/local/bin:/home/d.lang/bin:/home/d.lang/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/usr/lib/jvm/java-13-oracle/bin:/usr/lib/jvm/java-13-oracle/db/bin:/home/d.lang/.fzf/bin"  /home/d.lang/.local/bin/cmake /home/d.lang/br-test-pkg/bootlin-armv5-uclibc/build/dbus-cxx-2.1.0/ -DCMAKE_TOOLCHAIN_FILE="/home/d.lang/br-test-pkg/bootlin-armv5-uclibc/host/share/buildroot/toolchainfile.cmake" -DCMAKE_INSTALL_PREFIX="/usr" -DCMAKE_COLOR_MAKEFILE=OFF -DBUILD_DOC=OFF -DBUILD_DOCS=OFF -DBUILD_EXAMPLE=OFF -DBUILD_EXAMPLES=OFF -DBUILD_TEST=OFF -DBUILD_TESTS=OFF -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=ON  -DENABLE_QT_SUPPORT=OFF -DENABLE_GLIB_SUPPORT=OFF )
-- The C compiler identification is GNU 10.3.0
-- The CXX compiler identification is GNU 10.3.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /home/d.lang/br-test-pkg/bootlin-armv5-uclibc/host/bin/arm-linux-gcc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /home/d.lang/br-test-pkg/bootlin-armv5-uclibc/host/bin/arm-linux-g++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found PkgConfig: /home/d.lang/br-test-pkg/bootlin-armv5-uclibc/host/bin/pkg-config (found version "1.6.3") 
-- Checking for module 'sigc++-3.0'
--   Found sigc++-3.0, version 3.0.7
-- Performing Test NO_OP_NAMES
-- Performing Test NO_OP_NAMES - Success
-- Looking for C++ include cxxabi.h
-- Looking for C++ include cxxabi.h - found
-- Looking for abi::__cxa_demangle
-- Looking for abi::__cxa_demangle - found
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- 
-- 
-- dbus-cxx configuration summary:
-- 
--   Build type ...................... : Release
--   Install prefix .................. : /usr
--   Library location ................ : /usr/lib
--   C++ compiler .................... : /home/d.lang/br-test-pkg/bootlin-armv5-uclibc/host/bin/arm-linux-g++
--   Build examples .................. : OFF
--   Build tests ..................... : OFF
--   Build tools ..................... : OFF
--   Use bundled cppgenerate ......... : ON
--   Build website ................... : OFF
--   Enable code coverage report ..... : OFF
--   propagate_const ................. : TRUE
-- Library Support:
--   Qt .............................. : OFF
--   GLib ............................ : OFF
-- Configuring done
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    BUILD_DOC
    BUILD_DOCS
    BUILD_EXAMPLE
    BUILD_EXAMPLES
    BUILD_TEST
    BUILD_TESTS


-- Build files have been written to: /home/d.lang/br-test-pkg/bootlin-armv5-uclibc/build/dbus-cxx-2.1.0
dbus-cxx 2.1.0 Building
PATH="/home/d.lang/br-test-pkg/bootlin-armv5-uclibc/host/bin:/home/d.lang/br-test-pkg/bootlin-armv5-uclibc/host/sbin:/home/d.lang/.nvm/versions/node/v15.6.0/bin:/opt/doxygen/bin:/home/d.lang/bin:/usr/local/bin:/home/d.lang/bin:/home/d.lang/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin:/usr/lib/jvm/java-13-oracle/bin:/usr/lib/jvm/java-13-oracle/db/bin:/home/d.lang/.fzf/bin"  /usr/bin/make -j9  -C /home/d.lang/br-test-pkg/bootlin-armv5-uclibc/build/dbus-cxx-2.1.0/
Scanning dependencies of target dbus-cxx
[  2%] Building CXX object CMakeFiles/dbus-cxx.dir/dbus-cxx/callmessage.cpp.o
[  4%] Building CXX object CMakeFiles/dbus-cxx.dir/dbus-cxx/dispatcher.cpp.o
[  6%] Building CXX object CMakeFiles/dbus-cxx.dir/dbus-cxx/connection.cpp.o
[  9%] Building CXX object CMakeFiles/dbus-cxx.dir/dbus-cxx/error.cpp.o
[ 11%] Building CXX object CMakeFiles/dbus-cxx.dir/dbus-cxx/errormessage.cpp.o
[ 13%] Building CXX object CMakeFiles/dbus-cxx.dir/dbus-cxx/interface.cpp.o
[ 18%] Building CXX object CMakeFiles/dbus-cxx.dir/dbus-cxx/interfaceproxy.cpp.o
[ 18%] Building CXX object CMakeFiles/dbus-cxx.dir/dbus-cxx/message.cpp.o
[ 20%] Building CXX object CMakeFiles/dbus-cxx.dir/dbus-cxx/messageappenditerator.cpp.o
In file included from /home/d.lang/br-test-pkg/bootlin-armv5-uclibc/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/10.3.0/bits/ios_base.h:41,
                 from /home/d.lang/br-test-pkg/bootlin-armv5-uclibc/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/10.3.0/ios:42,
                 from /home/d.lang/br-test-pkg/bootlin-armv5-uclibc/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/10.3.0/istream:38,
                 from /home/d.lang/br-test-pkg/bootlin-armv5-uclibc/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/10.3.0/sstream:38,
                 from /home/d.lang/br-test-pkg/bootlin-armv5-uclibc/build/dbus-cxx-2.1.0/dbus-cxx/signal.h:19,
                 from /home/d.lang/br-test-pkg/bootlin-armv5-uclibc/host/arm-buildroot-linux-uclibcgnueabi/sysroot/usr/include/pthread.h:28,
                 from /home/d.lang/br-test-pkg/bootlin-armv5-uclibc/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/10.3.0/arm-buildroot-linux-uclibcgnueabi/bits/gthr-default.h:35,
                 from /home/d.lang/br-test-pkg/bootlin-armv5-uclibc/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/10.3.0/arm-buildroot-linux-uclibcgnueabi/bits/gthr.h:148,
                 from /home/d.lang/br-test-pkg/bootlin-armv5-uclibc/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/10.3.0/ext/atomicity.h:35,
                 from /home/d.lang/br-test-pkg/bootlin-armv5-uclibc/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/10.3.0/bits/basic_string.h:39,
                 from /home/d.lang/br-test-pkg/bootlin-armv5-uclibc/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/10.3.0/string:55,
                 from /home/d.lang/br-test-pkg/bootlin-armv5-uclibc/build/dbus-cxx-2.1.0/dbus-cxx/error.h:20,
                 from /home/d.lang/br-test-pkg/bootlin-armv5-uclibc/build/dbus-cxx-2.1.0/dbus-cxx/error.cpp:19:
/home/d.lang/br-test-pkg/bootlin-armv5-uclibc/host/opt/ext-toolchain/arm-buildroot-linux-uclibcgnueabi/include/c++/10.3.0/bits/locale_classes.h:338:12: error: ‘__gthread_once_t’ does not name a type; did you mean ‘pthread_once_t’?
  338 |     static __gthread_once_t _S_once;
      |            ^~~~~~~~~~~~~~~~
      |            pthread_once_t
```

Adding the dbus-cxx subfolders as an include path might override system headers (signal.h for gcc 10).
By removing the subfolders, includes can happen via `#include "..."` or via `#include <dbus-cxx/...>`.