### PR TITLE
use uid_t instead of __uid_t

### DIFF
--- a/dbus-cxx/sasl.cpp
+++ b/dbus-cxx/sasl.cpp
@@ -70,7 +70,7 @@ std::tuple<bool, bool, std::vector<uint8_t>> SASL::authenticate() {
     bool success = false;
     bool negotiatedFD = false;
     std::vector<uint8_t> serverGUID;
-    __uid_t uid = getuid();
+    uid_t uid = getuid();
     std::string line;
     std::smatch regex_match;
 


### PR DESCRIPTION
uclibc and glibc define getuid() as
extern __uid_t getuid (void) __THROW;
https://elixir.bootlin.com/glibc/glibc-2.34/source/posix/unistd.h#L698
which is a typedef for unsigned int.

musl uses uid_t as return type
uid_t getuid(void);
https://elixir.bootlin.com/musl/v1.2.2/source/include/unistd.h#L108
which is a typedef to unsigned.

glibc and uclibc include typedefs from __uid_t to uid_t,
which means one should be able to use uid_t as a replacement
for __uid_t and make compiling with all three c standard libraries
possible.