### PR TITLE
Fix move constructor for Variant

### DIFF
--- a/dbus-cxx/variant.cpp
+++ b/dbus-cxx/variant.cpp
@@ -135,7 +135,7 @@ Variant::Variant( const Variant& other ) :
 
 Variant::Variant( Variant&& other ) :
     m_currentType( std::exchange( other.m_currentType, DataType::INVALID ) ),
-    m_signature( std::exchange( other.m_signature, "" ) ),
+    m_signature( std::move( other.m_signature ) ),
     m_marshaled( std::move( other.m_marshaled ) ),
     m_dataAlignment( std::exchange( other.m_dataAlignment, 0 ) ){
 }


### PR DESCRIPTION
Move constuctor for Variant was removing the m_signature from both new and other object. Use std::move for the m_signature member to get the correct behavior.

This was causing wrong message generated for method calls when the Variants were created and passed inline, causing the move constructor to be used.