### PR TITLE
Core library builds on Windows (again)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,6 +229,18 @@ if( LIBRT )
 	list( APPEND DBUS_CXX_LIBRARIES ${LIBRT} )
 endif( LIBRT )
 
+
+#
+# Target for the library
+#
+link_directories( ${sigc_LIBRARY_DIRS} )
+add_library( dbus-cxx SHARED ${DBUS_CXX_SOURCES} ${DBUS_CXX_HEADERS} )
+set_target_properties( dbus-cxx PROPERTIES VERSION 2.0.0 SOVERSION 2 )
+target_link_libraries( dbus-cxx ${DBUS_CXX_LIBRARIES} )
+target_include_directories( dbus-cxx INTERFACE
+    $<INSTALL_INTERFACE:include/dbus-cxx-${DBUS_CXX_INCLUDE_VERSION}>
+)
+
 if( WIN32 )
     if( CMAKE_SYSTEM_VERSION )
         set( ver ${CMAKE_SYSTEM_VERSION} )
@@ -253,19 +265,7 @@ if( WIN32 )
     endif( MSVC AND (MSVC_VERSION GREATER_EQUAL 1914) )
 
     add_subdirectory( compat )
-    list( APPEND DBUS_CXX_LIBRARIES dbus-cxx-compat )
 endif( WIN32 )
-
-#
-# Target for the library
-#
-link_directories( ${sigc_LIBRARY_DIRS} )
-add_library( dbus-cxx SHARED ${DBUS_CXX_SOURCES} ${DBUS_CXX_HEADERS} )
-set_target_properties( dbus-cxx PROPERTIES VERSION 2.0.0 SOVERSION 2 )
-target_link_libraries( dbus-cxx ${DBUS_CXX_LIBRARIES} )
-target_include_directories( dbus-cxx INTERFACE
-    $<INSTALL_INTERFACE:include/dbus-cxx-${DBUS_CXX_INCLUDE_VERSION}>
-)
 
 # Dbus-cxx requires at least C++17 due to libsigc++-3.0
 set_property( TARGET dbus-cxx PROPERTY CXX_STANDARD 17 )

--- a/compat/CMakeLists.txt
+++ b/compat/CMakeLists.txt
@@ -13,13 +13,15 @@
 #   along with this software. If not see <http://www.gnu.org/licenses/>.  
 
 set( dbus-cxx-compat-sources
-        fcntl.c
-        getdtablesize.c
-        pipe2.c
-        poll.c
-        posix_win.c
+        compat/fcntl.c
+        compat/getdtablesize.c
+        compat/pipe2.c
+        compat/poll.c
+        compat/posix_win.c
 )
 
-add_library( dbus-cxx-compat OBJECT ${dbus-cxx-compat-sources} )
-target_include_directories( dbus-cxx-compat PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}" )
-target_link_libraries( dbus-cxx-compat PUBLIC "Ws2_32.lib" )
+target_sources(dbus-cxx PRIVATE ${dbus-cxx-compat-sources})
+target_include_directories (dbus-cxx PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
+
+cmake_policy(SET CMP0079 NEW)  # allow linking libraries in dbus-cxx from this subdirectory
+target_link_libraries( dbus-cxx "Ws2_32.lib" )

--- a/dbus-cxx/matchrule.h
+++ b/dbus-cxx/matchrule.h
@@ -8,6 +8,7 @@
 #ifndef DBUSCXX_MATCH_RULE_H
 #define DBUSCXX_MATCH_RULE_H
 
+#include <string>
 #include <memory>
 #include <dbus-cxx/dbus-cxx-config.h>
 

--- a/dbus-cxx/sendmsgtransport.cpp
+++ b/dbus-cxx/sendmsgtransport.cpp
@@ -458,14 +458,5 @@ void SendmsgTransport::purgeData(){
 //    too long to fit in the supplied buffers, and MSG_PEEK is not set in
 //    the flags argument, the excess bytes shall be discarded....
     // https://man7.org/linux/man-pages/man3/recvmsg.3p.html
-    struct msghdr hdr;
-    struct iovec iov;
-
-    ::memset( &hdr, 0, sizeof( hdr ) );
-    ::memset( &iov, 0, sizeof( iov ) );
-
-    hdr.msg_iov = &iov;
-    hdr.msg_iovlen = 1;
-
     m_priv->receive( 0, m_priv->rx_control_capacity, 0, 0 );
 }

--- a/dbus-cxx/variantiterator.cpp
+++ b/dbus-cxx/variantiterator.cpp
@@ -423,7 +423,7 @@ VariantIterator::operator std::string() {
     }
 }
 
-VariantIterator::operator Variant() {
+VariantIterator::operator DBus::Variant() {
     switch( this->arg_type() ) {
     case DataType::VARIANT: return get_variant();
 

--- a/dbus-cxx/variantiterator.h
+++ b/dbus-cxx/variantiterator.h
@@ -61,7 +61,7 @@ public:
     operator int64_t();
     operator double();
     operator std::string();
-    operator Variant();
+    operator DBus::Variant();
 
     template <typename T>
     operator std::vector<T>() {


### PR DESCRIPTION
This change gets dbus-cxx building again for Windows.  It looks like some minor changes have broken it since Windows support was added a few years ago

I haven't gotten dbus-cxx functionally working yet on Windows though.  It looks like we will need to implement the tcp transport to get things fully working on Windows and that doesn't look too hard, so possible upcoming PR for that also.

* Changed the dbus-cxx-compat to not be its own library, instead it just adds in sources to dbus-cxx, this requires dbus-cxx to be created before the windows compat folder is included.
  *  As a library, cmake wants it to provide install settings, which doesn't make sense for object files.
  * I'm very new to cmake, let me know if there's better ways to do this
* Added missing header in matchrule.h
* Removed dead(?) code in purgeData that doesn't build on windows
* Added a namespace to the operator Variant in variantiterator, not sure why msvc has issues with this.

Thanks for maintaining this project!

(fyi I'm OOO for a week tomorrow,I'll look at any responses to this PR once I'm back)