### PR TITLE
Add friendly hint when user session not found

### DIFF
--- a/dbus-cxx/connection.cpp
+++ b/dbus-cxx/connection.cpp
@@ -128,6 +128,7 @@ Connection::Connection( BusType type ) {
         char* env_address = getenv( "DBUS_SESSION_BUS_ADDRESS" );
 
         if( env_address == nullptr ) {
+            SIMPLELOGGER_ERROR( LOGGER_NAME, "Env `DBUS_SESSION_BUS_ADDRESS` not found, fail to open transport" );
             return;
         }
 
@@ -200,7 +201,7 @@ Connection::operator bool() const {
 }
 
 bool Connection::is_valid() const {
-    return m_priv->m_transport.operator bool() && m_priv->m_transport->is_valid();
+    return m_priv->m_transport && m_priv->m_transport.operator bool() && m_priv->m_transport->is_valid();
 }
 
 bool Connection::bus_register() {


### PR DESCRIPTION
In some cases, users may try to connect dbus session as root user (such as running a program in systemd without the `--user` argument), which will cause the dbus-cxx library to panic because the control flow is simply break there, and no caller check if the `m_priv->m_transport` is a non-null value. These will cause the whole program to panic without any useful message.

This commit adds pointer validation and add an error message if it fails to find the `DBUS_SESSION_BUS_ADDRESS` environment variable.