### PR TITLE
Add Debian packaging support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -411,6 +411,9 @@ endif( ENABLE_CODE_COVERAGE_REPORT )
 set(CPACK_SOURCE_PACKAGE_FILE_NAME "dbus-cxx-${dbus-cxx_VERSION}")
 set(CPACK_SOURCE_GENERATOR "TGZ")
 set(CPACK_SOURCE_IGNORE_FILES ".git/;build/")
+
+set(CPACK_GENERATOR "DEB")
+set(CPACK_PACKAGE_CONTACT "https://github.com/dbus-cxx/dbus-cxx")
 include(CPack)
 
 #


### PR DESCRIPTION
Hello,

We need a Debian package in our project. The existing repository from the documentation seems to be offline. However, it is easy to generate the package using cmake (only a very simplified one for now, probably missing some dependencies and the development package should be split).

Is this something you're interested in? To know if I should spend some more time improving it. Otherwise we can keep this patch in our internal repository and maintain it on our side.

Thanks for your feedback!