### PR TITLE
Support building from subdirectory, use PkgConfig:: targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,16 @@
-#   This file is part of the dbus-cxx library.                            
-#                                                                         
-#   The dbus-cxx library is free software; you can redistribute it and/or 
-#   modify it under the terms of the GNU General Public License           
-#   version 3 as published by the Free Software Foundation.               
-#                                                                         
-#   The dbus-cxx library is distributed in the hope that it will be       
-#   useful, but WITHOUT ANY WARRANTY; without even the implied warranty   
-#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU   
-#   General Public License for more details.                              
-#                                                                         
-#   You should have received a copy of the GNU General Public License     
-#   along with this software. If not see <http://www.gnu.org/licenses/>.  
+#   This file is part of the dbus-cxx library.
+#
+#   The dbus-cxx library is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License
+#   version 3 as published by the Free Software Foundation.
+#
+#   The dbus-cxx library is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this software. If not see <http://www.gnu.org/licenses/>.
 cmake_minimum_required( VERSION 3.12 )
 project( dbus-cxx VERSION 2.5.1 )
 
@@ -18,7 +18,6 @@ list(APPEND CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake-modules")
 
 include( CheckIncludeFiles )
 include( GNUInstallDirs )
-include( FindPkgConfig )
 include( CheckTypeSize )
 include( CTest )
 include( CheckCXXSymbolExists )
@@ -26,6 +25,8 @@ include( CheckCXXCompilerFlag )
 IF( CMAKE_BUILD_TYPE MATCHES Debug )
 include( CodeCoverage )
 ENDIF( CMAKE_BUILD_TYPE MATCHES Debug )
+
+find_package(PkgConfig REQUIRED)
 
 # The INCLUDE_VERSION variable is used for includes
 # it is related to, but not the same as, the normal project version
@@ -35,7 +36,7 @@ set( DBUS_CXX_INCLUDE_VERSION 2.0 )
 set( PKG_VERSION ${dbus-cxx_VERSION} )
 
 # Our required dependencies: libsigc++ 3.0
-pkg_check_modules( sigc REQUIRED sigc++-3.0 )
+pkg_check_modules( sigc REQUIRED IMPORTED_TARGET sigc++-3.0 )
 
 #
 # Check our options
@@ -117,7 +118,7 @@ if( ${UNUSED_RESULT} )
     set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wunused-result" )
 endif( ${UNUSED_RESULT} )
 
-# 
+#
 # All sources
 #
 set( DBUS_CXX_SOURCES
@@ -223,12 +224,10 @@ set( DBUS_CXX_HEADERS
     dbus-cxx/multiplereturn.h
 )
 
-set( DBUS_CXX_INCLUDE_DIRECTORIES 
-    ${PROJECT_SOURCE_DIR} 
+set( DBUS_CXX_INCLUDE_DIRECTORIES
+    ${PROJECT_SOURCE_DIR}
     ${PROJECT_BINARY_DIR} )
-include_directories( ${DBUS_CXX_INCLUDE_DIRECTORIES} 
-    ${dbus_INCLUDE_DIRS} 
-    ${sigc_INCLUDE_DIRS} )
+include_directories( ${DBUS_CXX_INCLUDE_DIRECTORIES} )
 
 
 #
@@ -236,7 +235,7 @@ include_directories( ${DBUS_CXX_INCLUDE_DIRECTORIES}
 #
 set( THREADS_PREFER_PTHREAD_FLAG ON )
 find_package( Threads REQUIRED )
-set( DBUS_CXX_LIBRARIES ${sigc_LIBRARIES} Threads::Threads )
+set( DBUS_CXX_LIBRARIES PkgConfig::sigc Threads::Threads )
 
 find_library( LIBRT rt )
 if( LIBRT )
@@ -247,11 +246,12 @@ endif( LIBRT )
 #
 # Target for the library
 #
-link_directories( ${sigc_LIBRARY_DIRS} )
 add_library( dbus-cxx SHARED ${DBUS_CXX_SOURCES} ${DBUS_CXX_HEADERS} )
 set_target_properties( dbus-cxx PROPERTIES VERSION 2.0.0 SOVERSION 2 )
 target_link_libraries( dbus-cxx ${DBUS_CXX_LIBRARIES} )
 target_include_directories( dbus-cxx INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
     $<INSTALL_INTERFACE:include/dbus-cxx-${DBUS_CXX_INCLUDE_VERSION}>
 )
 
@@ -376,7 +376,7 @@ endif( ENABLE_EXAMPLES )
 # Include the directory for the tools
 #
 if( ENABLE_TOOLS )
-    pkg_check_modules( expat REQUIRED expat )
+    pkg_check_modules( expat REQUIRED IMPORTED_TARGET expat )
     add_subdirectory( tools )
 endif( ENABLE_TOOLS )
 
@@ -384,7 +384,7 @@ endif( ENABLE_TOOLS )
 # If we want to build the site, we must have doxygen
 #
 if( BUILD_SITE )
-    find_package( Doxygen 
+    find_package( Doxygen
                   REQUIRED dot )
     file( COPY ${PROJECT_SOURCE_DIR}/doc/
           DESTINATION ${PROJECT_BINARY_DIR}/doc/ )
@@ -408,7 +408,7 @@ endif( BUILD_SITE )
 # Check if tests are enabled
 #
 if( BUILD_TESTING )
-    pkg_check_modules( expat REQUIRED expat )
+    pkg_check_modules( expat REQUIRED IMPORTED_TARGET expat )
     add_subdirectory( unit-tests )
     if( ENABLE_TOOLS )
         add_subdirectory( unit-tests/tools-tests )

--- a/dbus-cxx-glib/CMakeLists.txt
+++ b/dbus-cxx-glib/CMakeLists.txt
@@ -12,7 +12,7 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this software. If not see <http://www.gnu.org/licenses/>.
 
-pkg_check_modules( glib REQUIRED glib-2.0 )
+pkg_check_modules( glib REQUIRED IMPORTED_TARGET glib-2.0 )
 
 set( dbus-cxx-glib-headers dbus-cxx-glib.h glibdispatcher.h )
 set( dbus-cxx-glib-sources glibdispatcher.cpp )
@@ -22,12 +22,12 @@ set_target_properties( dbus-cxx-glib PROPERTIES
     VERSION 2.0.0 SOVERSION 2
     PUBLIC_HEADER "${dbus-cxx-glib-headers}"
 )
-target_link_libraries( dbus-cxx-glib PUBLIC dbus-cxx ${sigc_LIBS} ${LIBRT} )
+target_link_libraries( dbus-cxx-glib PUBLIC dbus-cxx PkgConfig::sigc ${LIBRT} )
 target_include_directories( dbus-cxx-glib INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include/dbus-cxx-glib-${DBUS_CXX_INCLUDE_VERSION}>
 )
-target_include_directories( dbus-cxx-glib PUBLIC ${glib_INCLUDE_DIRS} )
-target_link_libraries( dbus-cxx-glib ${glib_LIBS} )
+target_link_libraries( dbus-cxx-glib PUBLIC PkgConfig::glib )
 
 set_property( TARGET dbus-cxx-glib PROPERTY CXX_STANDARD 17 )
 

--- a/dbus-cxx-glib/unit-tests/CMakeLists.txt
+++ b/dbus-cxx-glib/unit-tests/CMakeLists.txt
@@ -12,16 +12,17 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this software. If not see <http://www.gnu.org/licenses/>.
 
-set( TEST_INCLUDES ${sigc_INCLUDE_DIRS} ${cppgenerate_INCLUDE_DIRS} )
-set( TEST_LINK dbus-cxx dbus-cxx-glib ${glib_LDFLAGS} ${sigc_LDFLAGS} ${popt_LDFLAGS} ${expat_LDFLAGS} ${LIBRT} )
+pkg_check_modules( expat REQUIRED IMPORTED_TARGET expat )
+pkg_check_modules( popt REQUIRED IMPORTED_TARGET popt )
+
+set( TEST_INCLUDES ${cppgenerate_INCLUDE_DIRS} )
+set( TEST_LINK dbus-cxx dbus-cxx-glib PkgConfig::glib PkgConfig::sigc PkgConfig::popt PkgConfig::expat ${LIBRT} )
 
 link_directories( ${CMAKE_BINARY_DIR} )
 
 include_directories( ${CMAKE_SOURCE_DIR}/dbus-cxx
     ${CMAKE_BINARY_DIR}/dbus-cxx
-    ${CMAKE_SOURCE_DIR}/dbus-cxx-glib
-    ${dbus_INCLUDE_DIRS}
-    ${sigc_INCLUDE_DIRS} )
+    ${CMAKE_SOURCE_DIR}/dbus-cxx-glib )
 
 add_executable( test-glib-dispatcher test-glib-dispatcher.cpp calleeclass.cpp )
 target_link_libraries( test-glib-dispatcher ${TEST_LINK} )

--- a/dbus-cxx-qt/CMakeLists.txt
+++ b/dbus-cxx-qt/CMakeLists.txt
@@ -28,8 +28,9 @@ set_target_properties( dbus-cxx-qt PROPERTIES
     VERSION 2.0.0 SOVERSION 2
     PUBLIC_HEADER "${dbus-cxx-qt-headers}"
 )
-target_link_libraries( dbus-cxx-qt PUBLIC Qt5::Core dbus-cxx ${sigc_LIBS} ${LIBRT} )
+target_link_libraries( dbus-cxx-qt PUBLIC Qt5::Core dbus-cxx PkgConfig::sigc ${LIBRT} )
 target_include_directories( dbus-cxx-qt INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include/dbus-cxx-qt-${DBUS_CXX_INCLUDE_VERSION}>
 )
 

--- a/dbus-cxx-qt/unit-tests/CMakeLists.txt
+++ b/dbus-cxx-qt/unit-tests/CMakeLists.txt
@@ -18,16 +18,17 @@ set(CMAKE_AUTOUIC ON)
 
 find_package(Qt5 COMPONENTS Core REQUIRED)
 
-set( TEST_INCLUDES ${sigc_INCLUDE_DIRS} ${cppgenerate_INCLUDE_DIRS} )
-set( TEST_LINK dbus-cxx dbus-cxx-qt Qt5::Core ${sigc_LDFLAGS} ${popt_LDFLAGS} ${expat_LDFLAGS} ${LIBRT} )
+pkg_check_modules( expat REQUIRED IMPORTED_TARGET expat )
+pkg_check_modules( popt REQUIRED IMPORTED_TARGET popt )
+
+set( TEST_INCLUDES ${cppgenerate_INCLUDE_DIRS} )
+set( TEST_LINK dbus-cxx dbus-cxx-qt Qt5::Core PkgConfig::sigc PkgConfig::popt PkgConfig::expat ${LIBRT} )
 
 link_directories( ${CMAKE_BINARY_DIR} )
 
 include_directories( ${CMAKE_SOURCE_DIR}/dbus-cxx
     ${CMAKE_BINARY_DIR}/dbus-cxx
-    ${CMAKE_SOURCE_DIR}/dbus-cxx-qt
-    ${dbus_INCLUDE_DIRS}
-    ${sigc_INCLUDE_DIRS} )
+    ${CMAKE_SOURCE_DIR}/dbus-cxx-qt )
 
 add_executable( test-qt-dispatcher test-qt-dispatcher.cpp calleeclass.cpp )
 target_link_libraries( test-qt-dispatcher ${TEST_LINK} )

--- a/dbus-cxx-uv/CMakeLists.txt
+++ b/dbus-cxx-uv/CMakeLists.txt
@@ -22,8 +22,9 @@ set_target_properties( dbus-cxx-uv PROPERTIES
     VERSION 2.0.0 SOVERSION 2
     PUBLIC_HEADER "${dbus-cxx-uv-headers}"
 )
-target_link_libraries( dbus-cxx-uv PUBLIC dbus-cxx ${sigc_LIBS} ${LIBRT} )
+target_link_libraries( dbus-cxx-uv PUBLIC dbus-cxx PkgConfig::sigc ${LIBRT} )
 target_include_directories( dbus-cxx-uv INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include/dbus-cxx-uv-${DBUS_CXX_INCLUDE_VERSION}>
 )
 target_link_libraries( dbus-cxx-uv PUBLIC ${LIBUV_LIBRARIES} )

--- a/doc/10-quick-start.md
+++ b/doc/10-quick-start.md
@@ -33,10 +33,9 @@ this, simply add the following lines to your CMakeLists.txt:
 
 ```
 include( FindPkgConfig )
-pkg_check_modules( dbus-cxx REQUIRED dbus-cxx-2.0 )
+pkg_check_modules( dbus-cxx REQUIRED IMPORTED_TARGET dbus-cxx-2.0 )
 
-target_include_directories( exe ${dbus-cxx_INCLUDE_DIRS} )
-target_link_libraries( exe ${dbus-cxx_LDFLAGS} )
+target_link_libraries( exe PkgConfig::dbus-cxx )
 ```
 
 If you want to use the `find_package` directive of CMake, your CMakeLists.txt file
@@ -44,18 +43,17 @@ should look something like the following:
 
 ```
 include( FindPkgConfig )
-pkg_check_modules( sigc REQUIRED sigc++-3.0 )
+pkg_check_modules( sigc REQUIRED IMPORTED_TARGET sigc++-3.0 )
 find_package( dbus-cxx REQUIRED )
 find_package( Threads )
 
-target_link_libraries( exe dbus-cxx::dbus-cxx Threads::Threads ${sigc_LIBRARIES} )
-target_include_directories( exe PRIVATE ${sigc_INCLUDE_DIRS} )
+target_link_libraries( exe dbus-cxx::dbus-cxx Threads::Threads PkgConfig::sigc )
 ```
 
 Note that you need to use both pkg-config and the `find_package` directive,
 because libsigc++ does not provide a CMake package at this point.
 
-## qmake + dbus-cxx 
+## qmake + dbus-cxx
 
 Because of Qt's signal/slot mechanism, dbus-cxx will not work directly with Qt.  Assuming that you are using QMake,
 you will need to add the following lines to your .pro file:
@@ -66,11 +64,11 @@ unix:PKGCONFIG += dbus-cxx-qt-2.0
 ```
 Note that this will also allow you to use the Qt integration with dbus-cxx.
 
-At any point in your Qt program, you need to use Qt signals or slots, use the macros Q_SIGNALS or Q_SLOTS to define 
+At any point in your Qt program, you need to use Qt signals or slots, use the macros Q_SIGNALS or Q_SLOTS to define
 your signals/slots.
 
 ## Autotools + dbus-cxx
- 
+
 If you are using autotools, modify configure.ac (or configure.in ) with the following lines:
 ```
 PKG_CHECK_MODULES(PROJECT_DBUSCXX,[dbus-cxx-2.0 >= 2.0.0])
@@ -288,7 +286,7 @@ our `main()` function and the calls will be handled in the dispatcher's
 threads.
 ```{.cpp}
   std::this_thread::sleep_for(std::chrono::seconds(10));
-  
+
   return 0;
 }
 ```
@@ -377,10 +375,10 @@ Finally, we can print out the results.
 ------------------------
 The following pages provide the quick-start for dbus-cxx:
 
-1. @subpage quick_start_client_0.md 
-2. @subpage quick_start_cmake.md 
-3. @subpage quick_start_example_0.md 
-4. @subpage quick_start_initial_concepts.md 
-5. quick_start.md 
-6. quick_start_pkgconfig.md 
+1. @subpage quick_start_client_0.md
+2. @subpage quick_start_cmake.md
+3. @subpage quick_start_example_0.md
+4. @subpage quick_start_initial_concepts.md
+5. quick_start.md
+6. quick_start_pkgconfig.md
 7. quick_start_server_0.md

--- a/examples/basics/methods/CMakeLists.txt
+++ b/examples/basics/methods/CMakeLists.txt
@@ -1,33 +1,33 @@
 include( ../../examples-common.cmake )
 
-pkg_check_modules( popt REQUIRED popt )
+pkg_check_modules( popt REQUIRED IMPORTED_TARGET popt )
 
 if( ${dbus_FOUND} )
 	message("libdbus found, building libdbus examples")
 	add_executable( caller-c caller_c.cpp  )
-	target_link_libraries( caller-c ${EXAMPLES_LINK} ${popt_LDFLAGS} ${dbus_LDFLAGS} )
+	target_link_libraries( caller-c ${EXAMPLES_LINK} PkgConfig::popt PkgConfig::dbus )
 
 	add_executable( callee-c callee_c.cpp  )
-	target_link_libraries( callee-c ${EXAMPLES_LINK} ${popt_LDFLAGS} ${dbus_LDFLAGS} )
+	target_link_libraries( callee-c ${EXAMPLES_LINK} PkgConfig::popt PkgConfig::dbus )
 endif( ${dbus_FOUND} )
 
 add_executable( caller caller.cpp  )
-target_link_libraries( caller ${EXAMPLES_LINK} ${popt_LDFLAGS} )
+target_link_libraries( caller ${EXAMPLES_LINK} PkgConfig::popt )
 
 add_executable( callee callee.cpp  )
-target_link_libraries( callee ${EXAMPLES_LINK} ${popt_LDFLAGS} )
+target_link_libraries( callee ${EXAMPLES_LINK} PkgConfig::popt )
 
 add_executable( callee-2 callee_2.cpp  )
-target_link_libraries( callee-2 ${EXAMPLES_LINK} ${popt_LDFLAGS} )
+target_link_libraries( callee-2 ${EXAMPLES_LINK} PkgConfig::popt )
 
 add_executable( callee-object callee_object.cpp  )
-target_link_libraries( callee-object ${EXAMPLES_LINK} ${popt_LDFLAGS} )
+target_link_libraries( callee-object ${EXAMPLES_LINK} PkgConfig::popt )
 
 add_executable( caller-object caller_object.cpp  )
-target_link_libraries( caller-object ${EXAMPLES_LINK} ${popt_LDFLAGS} )
+target_link_libraries( caller-object ${EXAMPLES_LINK} PkgConfig::popt )
 
 add_executable( callee-object-inherited callee_object_inherited.cpp  )
-target_link_libraries( callee-object-inherited ${EXAMPLES_LINK} ${popt_LDFLAGS} )
+target_link_libraries( callee-object-inherited ${EXAMPLES_LINK} PkgConfig::popt )
 
 add_executable( caller-dispatched caller_dispatched.cpp  )
-target_link_libraries( caller-dispatched ${EXAMPLES_LINK} ${popt_LDFLAGS} )
+target_link_libraries( caller-dispatched ${EXAMPLES_LINK} PkgConfig::popt )

--- a/examples/basics/signals/CMakeLists.txt
+++ b/examples/basics/signals/CMakeLists.txt
@@ -2,10 +2,10 @@ include( ../../examples-common.cmake )
 
 if( ${dbus_FOUND} )
 	add_executable( signal-emitter-c signal_emitter_c.cpp  )
-	target_link_libraries( signal-emitter-c ${EXAMPLES_LINK} ${dbus_LDFLAGS} )
+	target_link_libraries( signal-emitter-c ${EXAMPLES_LINK} PkgConfig::dbus )
 
 	add_executable( signal-receiver-c signal_receiver_c.cpp  )
-	target_link_libraries( signal-receiver-c ${EXAMPLES_LINK} ${dbus_LDFLAGS} )
+	target_link_libraries( signal-receiver-c ${EXAMPLES_LINK} PkgConfig::dbus )
 endif( ${dbus_FOUND} )
 
 add_executable( signal-emitter-raw signal_emitter_raw.cpp  )

--- a/examples/examples-common.cmake
+++ b/examples/examples-common.cmake
@@ -1,12 +1,9 @@
-pkg_check_modules( dbus dbus-1 )
+pkg_check_modules( dbus IMPORTED_TARGET dbus-1 )
 
-set( EXAMPLES_INCLUDES ${sigc_INCLUDE_DIRS} )
-set( EXAMPLES_LINK dbus-cxx ${sigc_LDFLAGS} ${LIBRT} )
+set( EXAMPLES_LINK dbus-cxx PkgConfig::sigc ${LIBRT} PkgConfig::dbus )
 set( CMAKE_CXX_STANDARD 17 )
 
 link_directories( ${CMAKE_BINARY_DIR} )
 
 include_directories( ${CMAKE_SOURCE_DIR}/dbus-cxx
-    ${CMAKE_BINARY_DIR}/dbus-cxx 
-    ${dbus_INCLUDE_DIRS} 
-    ${sigc_INCLUDE_DIRS} )
+    ${CMAKE_BINARY_DIR}/dbus-cxx )

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,40 +1,31 @@
 # Check to see if we want to use the bundled libcppgenerate or not
 if( TOOLS_BUNDLED_CPPGENERATE )
-    include(${CMAKE_ROOT}/Modules/ExternalProject.cmake)
-    ExternalProject_Add( cppgenerate 
-                         SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/libcppgenerate
-                         DOWNLOAD_COMMAND ""
-                         INSTALL_COMMAND "")
-    ExternalProject_Get_Property( cppgenerate BINARY_DIR )
-    set( cppgenerate_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/libcppgenerate )
-    set( cppgenerate_LDFLAGS ${BINARY_DIR}/libcppgenerate.a )
+    add_subdirectory(libcppgenerate)
 else()
-    pkg_check_modules( cppgenerate REQUIRED cppgenerate-static )
+    pkg_check_modules( cppgenerate REQUIRED IMPORTED_TARGET cppgenerate-static )
+    add_library(cppgenerate_static ALIAS PkgConfig::cppgenerate)
 endif( TOOLS_BUNDLED_CPPGENERATE )
 
-pkg_check_modules( popt REQUIRED popt )
+pkg_check_modules( dbus REQUIRED IMPORTED_TARGET dbus-1 )
+pkg_check_modules( popt REQUIRED IMPORTED_TARGET popt )
 
-set( TOOLS_INCLUDES ${dbus_INCLUDE_DIRS} ${sigc_INCLUDE_DIRS} ${cppgenerate_INCLUDE_DIRS} )
-set( TOOLS_LINK dbus-cxx ${dbus_LDFLAGS} ${sigc_LDFLAGS} ${popt_LDFLAGS} ${expat_LDFLAGS} ${LIBRT} )
+set( TOOLS_LINK dbus-cxx PkgConfig::dbus PkgConfig::sigc PkgConfig::popt PkgConfig::expat ${LIBRT} )
 
 link_directories( ${CMAKE_BINARY_DIR} )
 
 include_directories( ${CMAKE_SOURCE_DIR}/dbus-cxx
-    ${CMAKE_BINARY_DIR}/dbus-cxx 
-    ${dbus_INCLUDE_DIRS} 
-    ${sigc_INCLUDE_DIRS}
-    ${cppgenerate_INCLUDE_DIRS} )
+    ${CMAKE_BINARY_DIR}/dbus-cxx )
 
-add_executable( dbus-cxx-xml2cpp 
+add_executable( dbus-cxx-xml2cpp
     xml2cpp.cpp
-    code-generator.cpp 
+    code-generator.cpp
     signal-info.cpp
     method-info.cpp
     property-info.cpp
     interface-info.cpp
     node-info.cpp
 )
-target_link_libraries( dbus-cxx-xml2cpp ${TOOLS_LINK} ${cppgenerate_LDFLAGS} )
+target_link_libraries( dbus-cxx-xml2cpp ${TOOLS_LINK} cppgenerate_static )
 install( TARGETS dbus-cxx-xml2cpp DESTINATION bin )
 set_property( TARGET dbus-cxx-xml2cpp PROPERTY CXX_STANDARD 17 )
 

--- a/tools/libcppgenerate/CMakeLists.txt
+++ b/tools/libcppgenerate/CMakeLists.txt
@@ -1,4 +1,4 @@
-# 
+#
 # This file is part of libcppgenerate
 #
 # Copyright 2018 Robert Middleton robert.middleton@rm5248.com
@@ -29,7 +29,7 @@ option( ENABLE_EXAMPLES "Enable the examples" OFF )
 #
 # Sources
 #
-set( CPPGENERATE_SOURCES 
+set( CPPGENERATE_SOURCES
   cppgenerate/class.cpp
   cppgenerate/method.cpp
   cppgenerate/variable.cpp
@@ -62,9 +62,11 @@ add_library( objlib OBJECT ${CPPGENERATE_SOURCES} ${CPPGENERATE_HEADERS} )
 set_property( TARGET objlib PROPERTY POSITION_INDEPENDENT_CODE 1)
 
 add_library( cppgenerate SHARED $<TARGET_OBJECTS:objlib>)
+target_include_directories( cppgenerate INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>)
 set_target_properties( cppgenerate PROPERTIES VERSION ${CPPGENERATE_VERSION} SOVERSION ${CPPGENERATE_MAJOR} )
 
 add_library( cppgenerate_static STATIC $<TARGET_OBJECTS:objlib>)
+target_include_directories( cppgenerate_static INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>)
 set_target_properties( cppgenerate_static PROPERTIES OUTPUT_NAME cppgenerate )
 
 #
@@ -115,7 +117,7 @@ IF( UNIX )
         "${CMAKE_CURRENT_SOURCE_DIR}/cppgenerate-static.pc.cmake"
         "${CMAKE_CURRENT_BINARY_DIR}/cppgenerate-static.pc"
     )
-    INSTALL( FILES 
+    INSTALL( FILES
              "${CMAKE_BINARY_DIR}/cppgenerate.pc"
              "${CMAKE_BINARY_DIR}/cppgenerate-static.pc"
              DESTINATION lib/pkgconfig)

--- a/unit-tests/CMakeLists.txt
+++ b/unit-tests/CMakeLists.txt
@@ -1,13 +1,12 @@
+pkg_check_modules( popt REQUIRED IMPORTED_TARGET popt )
 
-set( TEST_INCLUDES ${sigc_INCLUDE_DIRS} ${cppgenerate_INCLUDE_DIRS} )
-set( TEST_LINK dbus-cxx ${sigc_LDFLAGS} ${popt_LDFLAGS} ${expat_LDFLAGS} ${LIBRT} )
+set( TEST_INCLUDES ${cppgenerate_INCLUDE_DIRS} )
+set( TEST_LINK dbus-cxx PkgConfig::sigc PkgConfig::popt PkgConfig::expat ${LIBRT} )
 
 link_directories( ${CMAKE_BINARY_DIR} )
 
 include_directories( ${CMAKE_SOURCE_DIR}/dbus-cxx
-    ${CMAKE_BINARY_DIR}/dbus-cxx 
-    ${dbus_INCLUDE_DIRS} 
-    ${sigc_INCLUDE_DIRS} )
+    ${CMAKE_BINARY_DIR}/dbus-cxx )
 
 if( ENABLE_ROBUSTNESS_TESTS )
     add_subdirectory( robustness-tests )
@@ -193,7 +192,7 @@ add_test( NAME remove-handler COMMAND dbus-wrapper.sh signal-tests remove_handle
 #
 configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/dbus-wrapper-introspection-tests.sh ${CMAKE_CURRENT_BINARY_DIR}/dbus-wrapper-introspection-tests.sh COPYONLY)
 add_executable( introspection-tests introspection-test.cpp )
-target_link_libraries( introspection-tests ${TEST_LINK} ${expat_LDFLAGS} )
+target_link_libraries( introspection-tests ${TEST_LINK} PkgConfig::expat )
 target_include_directories( introspection-tests PUBLIC ${CMAKE_SOURCE_DIR} )
 target_include_directories( introspection-tests PUBLIC ${CMAKE_CURRENT_BINARY_DIR} )
 set_property( TARGET introspection-tests PROPERTY CXX_STANDARD 17 )

--- a/unit-tests/tools-tests/CMakeLists.txt
+++ b/unit-tests/tools-tests/CMakeLists.txt
@@ -1,4 +1,7 @@
-set( TEST_LINK dbus-cxx ${dbus_LDFLAGS} ${sigc_LDFLAGS} ${popt_LDFLAGS} ${expat_LDFLAGS} ${LIBRT} )
+pkg_check_modules( dbus REQUIRED IMPORTED_TARGET dbus-1 )
+pkg_check_modules( popt REQUIRED IMPORTED_TARGET popt )
+
+set( TEST_LINK dbus-cxx PkgConfig::dbus PkgConfig::sigc PkgConfig::popt PkgConfig::expat ${LIBRT} )
 
 #
 # Add a test that generates code from the XML file and then compiles it


### PR DESCRIPTION
Resolves #119

Also uses the `IMPORTED_TARGET` feature of `pkg_check_modules` so that including the target from the subdirectory automatically links the dependencies, e.g. libsigc++-3.0