### PR TITLE
Remove listeningSignals entry when calling RemoveMatch

### DIFF
--- a/dbus-cxx/connection.cpp
+++ b/dbus-cxx/connection.cpp
@@ -339,6 +339,7 @@ bool Connection::remove_match( const std::string& rule ) {
 
             if( count == 0 ){
                 m_priv->m_daemonProxy->RemoveMatch( rule );
+                m_priv->m_listeningSignals.erase(it);
             }
         }
     }


### PR DESCRIPTION
With  the changes in https://github.com/dbus-cxx/dbus-cxx/commit/39b43ac7c9f2d0e144be2cf80f1e35846ecfd845, matches are only added if we don't have them. But when `remove_match` is called, all listening-signals are removed & the count decreased to 0, `RemoveMatch` is called, but the rule entry isn't removed from `m_priv->m_listeningSignals`.

Therefore when calling `add_match` for the same rule again, it's already in the map & hence `AddMatch` isn't called again.

When deleting object again, it tries to remove the match again, but due to `AddMatch` not getting called before, the dbus returns a `The given match rule wasn't found and can't be removed` error.