### PR TITLE
Fixes and improvements to libuv integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ option( ENABLE_ROBUSTNESS_TESTS "Enable extended robustness tests.  These can be
 endif( BUILD_TESTING )
 option( ENABLE_QT_SUPPORT "Build libdbuscxx-qt for integration with Qt applications" OFF )
 option( ENABLE_UV_SUPPORT "Build libdbuscxx-uv for integration with libuv applications" OFF )
+option( UV_STATIC "Link statically with libuv when using it" OFF )
 
 # With glibc >= 2.35, it seems that we no longer need to link with -lrt:
 # https://sourceware.org/pipermail/libc-alpha/2021-August/129718.html
@@ -463,4 +464,4 @@ endif( BUILD_TESTING )
 message(STATUS "Library Support:" )
 message(STATUS "  Qt .............................. : ${ENABLE_QT_SUPPORT}")
 message(STATUS "  GLib ............................ : ${ENABLE_GLIB_SUPPORT}")
-message(STATUS "  libuv ........................... : ${ENABLE_UV_SUPPORT}")
+message(STATUS "  libuv ........................... : ${ENABLE_UV_SUPPORT} (static: ${UV_STATIC})")

--- a/dbus-cxx-uv/CMakeLists.txt
+++ b/dbus-cxx-uv/CMakeLists.txt
@@ -38,7 +38,7 @@ target_link_libraries( dbus-cxx-uv PUBLIC PkgConfig::libuv )
 set_property( TARGET dbus-cxx-uv PROPERTY CXX_STANDARD 17 )
 
 if( BUILD_TESTING )
-    #add_subdirectory( unit-tests )
+    add_subdirectory( unit-tests )
 endif( BUILD_TESTING )
 
 #

--- a/dbus-cxx-uv/CMakeLists.txt
+++ b/dbus-cxx-uv/CMakeLists.txt
@@ -12,7 +12,13 @@
 #   You should have received a copy of the GNU General Public License
 #   along with this software. If not see <http://www.gnu.org/licenses/>.
 
-pkg_search_module( LIBUV REQUIRED libuv )
+if( UV_STATIC )
+  set( LIBUV_PKG_NAME libuv-static )
+else()
+  set( LIBUV_PKG_NAME libuv )
+endif()
+
+pkg_check_modules( libuv REQUIRED IMPORTED_TARGET ${LIBUV_PKG_NAME} )
 
 set( dbus-cxx-uv-headers dbus-cxx-uv.h uvdispatcher.h )
 set( dbus-cxx-uv-sources dbus-cxx-uv.cpp uvdispatcher.cpp )
@@ -27,7 +33,7 @@ target_include_directories( dbus-cxx-uv INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include/dbus-cxx-uv-${DBUS_CXX_INCLUDE_VERSION}>
 )
-target_link_libraries( dbus-cxx-uv PUBLIC ${LIBUV_LIBRARIES} )
+target_link_libraries( dbus-cxx-uv PUBLIC PkgConfig::libuv )
 
 set_property( TARGET dbus-cxx-uv PROPERTY CXX_STANDARD 17 )
 
@@ -51,7 +57,7 @@ SET(PKG_CONFIG_CFLAGS
     "-I\${includedir}"
 )
 SET(PKG_CONFIG_REQUIRES
-    "dbus-cxx-2.0, libuv"
+    "dbus-cxx-2.0, ${LIBUV_PKG_NAME}"
 )
 
 CONFIGURE_FILE(

--- a/dbus-cxx-uv/dbus-cxx-uv.h
+++ b/dbus-cxx-uv/dbus-cxx-uv.h
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later OR BSD-3-Clause
-// SPDX-License-Identifier: LGPL-3.0-or-later OR BSD-3-Clause
 /***************************************************************************
  *   Copyright (C) 2020 by Robert Middleton                                *
  *   robert.middleton@rm5248.com                                           *

--- a/dbus-cxx-uv/unit-tests/CMakeLists.txt
+++ b/dbus-cxx-uv/unit-tests/CMakeLists.txt
@@ -1,0 +1,43 @@
+#   This file is part of the dbus-cxx library.
+#
+#   The dbus-cxx library is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License
+#   version 3 as published by the Free Software Foundation.
+#
+#   The dbus-cxx library is distributed in the hope that it will be
+#   useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+#   of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+#   General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this software. If not see <http://www.gnu.org/licenses/>.
+
+pkg_check_modules( expat REQUIRED IMPORTED_TARGET expat )
+pkg_check_modules( popt REQUIRED IMPORTED_TARGET popt )
+
+set( TEST_INCLUDES ${cppgenerate_INCLUDE_DIRS} )
+set( TEST_LINK dbus-cxx dbus-cxx-uv PkgConfig::libuv PkgConfig::sigc PkgConfig::popt PkgConfig::expat ${LIBRT} )
+
+link_directories( ${CMAKE_BINARY_DIR} )
+
+include_directories(
+    ${CMAKE_BINARY_DIR}/dbus-cxx
+    ${CMAKE_SOURCE_DIR}/dbus-cxx-uv )
+
+add_executable( test-uv-dispatcher test-uv-dispatcher.cpp calleeclass.cpp )
+target_link_libraries( test-uv-dispatcher ${TEST_LINK} )
+target_include_directories( test-uv-dispatcher PUBLIC ${CMAKE_SOURCE_DIR} )
+target_include_directories( test-uv-dispatcher PUBLIC ${CMAKE_CURRENT_BINARY_DIR} )
+set_property( TARGET test-uv-dispatcher PROPERTY CXX_STANDARD 17 )
+
+add_executable( uv-caller uv-caller.cpp )
+target_link_libraries( uv-caller ${TEST_LINK} )
+target_include_directories( uv-caller PUBLIC ${CMAKE_SOURCE_DIR} )
+target_include_directories( uv-caller PUBLIC ${CMAKE_CURRENT_BINARY_DIR} )
+set_property( TARGET uv-caller PROPERTY CXX_STANDARD 17 )
+
+configure_file( ${CMAKE_CURRENT_SOURCE_DIR}/dbus-wrapper-uv-tests.sh
+    ${CMAKE_CURRENT_BINARY_DIR}/dbus-wrapper-uv-tests.sh COPYONLY)
+
+add_test( NAME uv-dispatcher COMMAND dbus-wrapper-uv-tests.sh uv-dispatcher)
+#add_test( NAME uv-threaddispatcher COMMAND dbus-wrapper-uv-tests.sh standalone)

--- a/dbus-cxx-uv/unit-tests/calleeclass.cpp
+++ b/dbus-cxx-uv/unit-tests/calleeclass.cpp
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later OR BSD-3-Clause
+// SPDX-License-Identifier: LGPL-3.0-or-later OR BSD-3-Clause
+#include "calleeclass.h"
+
+CalleeClass::CalleeClass( std::string path ) :
+    DBus::Object ( path )
+{
+    create_method<int(int,int)>( "test.foo", "add", sigc::mem_fun( *this, &CalleeClass::add ) );
+}
+
+std::shared_ptr<CalleeClass> CalleeClass::create( std::string path ){
+    return std::shared_ptr<CalleeClass>( new CalleeClass( path ) );
+}
+
+int CalleeClass::add(int a, int b){
+    return a + b;
+}

--- a/dbus-cxx-uv/unit-tests/calleeclass.h
+++ b/dbus-cxx-uv/unit-tests/calleeclass.h
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later OR BSD-3-Clause
+// SPDX-License-Identifier: LGPL-3.0-or-later OR BSD-3-Clause
+#ifndef CALLEECLASS_H
+#define CALLEECLASS_H
+
+#include <dbus-cxx.h>
+
+class CalleeClass : public DBus::Object
+{
+private:
+    CalleeClass( std::string path );
+
+public:
+    static std::shared_ptr<CalleeClass> create( std::string path );
+
+    int add( int a, int b );
+};
+
+#endif // CALLEECLASS_H

--- a/dbus-cxx-uv/unit-tests/dbus-wrapper-uv-tests.sh
+++ b/dbus-cxx-uv/unit-tests/dbus-wrapper-uv-tests.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# launch up an instance of the dbus and source the data output
+# to see what the address is and what the PID is
+TMPFILE=$(mktemp)
+dbus-launch > $TMPFILE
+
+. $TMPFILE
+export DBUS_SESSION_BUS_ADDRESS
+export PATH=$PATH:$(pwd)
+
+./test-uv-dispatcher &
+SERVER_PID=$!
+sleep .1
+./uv-caller
+# get the exit code 
+EXIT_CODE=$?
+
+# wait for server to be done
+wait $SERVER_PID
+
+kill $DBUS_SESSION_BUS_PID
+rm $TMPFILE
+
+exit $EXIT_CODE

--- a/dbus-cxx-uv/unit-tests/test-uv-dispatcher.cpp
+++ b/dbus-cxx-uv/unit-tests/test-uv-dispatcher.cpp
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later OR BSD-3-Clause
+// SPDX-License-Identifier: LGPL-3.0-or-later OR BSD-3-Clause
+
+#include <uv.h>
+
+#include <dbus-cxx-uv.h>
+
+#include "calleeclass.h"
+
+static void timer_cb(uv_timer_t* h)
+{
+    uv_stop(uv_default_loop());
+}
+
+int main(int argc, char** argv){
+    DBus::set_logging_function( DBus::log_std_err );
+    DBus::set_log_level( SL_TRACE );
+
+    std::shared_ptr<DBus::Dispatcher> disp = DBus::Uv::UvDispatcher::create();
+
+    std::shared_ptr<DBus::Connection> conn = disp->create_connection( DBus::BusType::SESSION );
+    conn->request_name( "dbuscxx.test" );
+    std::shared_ptr<CalleeClass> callee = CalleeClass::create( "/test" );
+
+    conn->register_object( callee, DBus::ThreadForCalling::CurrentThread );
+
+    uv_timer_t uv_timer;
+
+    if (int r = uv_timer_init(uv_default_loop(), &uv_timer); r < 0) {
+        fprintf(stderr, "libuv failure: %s\n", uv_strerror(r));
+        return -1;
+    }
+
+    if (int r = uv_timer_start(&uv_timer, timer_cb, 1000, 0); r < 0) {
+        fprintf(stderr, "libuv failure: %s\n", uv_strerror(r));
+        return -1;
+    }
+
+    fprintf(stderr, "*** Before libuv loop\n");
+
+    if (int r = uv_run(uv_default_loop(), UV_RUN_DEFAULT); r < 0) {
+        fprintf(stderr, "libuv failure: %s\n", uv_strerror(r));
+        return -1;
+    }
+
+    fprintf(stderr, "*** After libuv loop\n");
+            
+    return 0;
+}

--- a/dbus-cxx-uv/unit-tests/uv-caller.cpp
+++ b/dbus-cxx-uv/unit-tests/uv-caller.cpp
@@ -1,0 +1,48 @@
+
+// SPDX-License-Identifier: LGPL-3.0-or-later OR BSD-3-Clause
+// SPDX-License-Identifier: LGPL-3.0-or-later OR BSD-3-Clause
+
+#include <uv.h>
+
+#include <dbus-cxx-uv.h>
+
+#include "calleeclass.h"
+
+int value = 0;
+
+static void timer_cb(uv_timer_t* h)
+{
+    auto methodref = *reinterpret_cast<std::shared_ptr<DBus::MethodProxy<int(int,int)>>*>(h->data);
+    value = (*methodref)( 5, 10 ); 
+    uv_stop(uv_default_loop());
+}
+
+int main(int argc, char** argv){
+    std::shared_ptr<DBus::Dispatcher> disp = DBus::Uv::UvDispatcher::create();
+    std::shared_ptr<DBus::Connection> conn = disp->create_connection( DBus::BusType::SESSION );
+    std::shared_ptr<DBus::ObjectProxy> proxy = conn->create_object_proxy( "dbuscxx.test", "/test" );
+    std::shared_ptr<DBus::MethodProxy<int(int,int)>> methodref = proxy->create_method<int(int,int)>( "test.foo", "add" );
+
+    uv_timer_t uv_timer;
+
+    if (int r = uv_timer_init(uv_default_loop(), &uv_timer); r < 0) {
+        fprintf(stderr, "libuv failure: %s\n", uv_strerror(r));
+        return -1;
+    }
+
+    uv_timer.data = &methodref;
+
+    if (int r = uv_timer_start(&uv_timer, timer_cb, 100, 0); r < 0) {
+        fprintf(stderr, "libuv failure: %s\n", uv_strerror(r));
+        return -1;
+    }
+
+    if (int r = uv_run(uv_default_loop(), UV_RUN_DEFAULT); r < 0) {
+        fprintf(stderr, "libuv failure: %s\n", uv_strerror(r));
+        return -1;
+    }
+    
+    fprintf(stderr, "*** %s got %d\n", argv[0], value);
+
+    return value != 15;
+}

--- a/dbus-cxx-uv/uvdispatcher.cpp
+++ b/dbus-cxx-uv/uvdispatcher.cpp
@@ -38,8 +38,89 @@ close_cb(uv_handle_t* h)
 }
 
 static void
+poll_cb(uv_poll_t* h, int status, int event);
+
+namespace
+{
+class UVPollConnection
+{
+public:
+    UVPollConnection(std::shared_ptr<DBus::Connection> connection) : connection(connection)
+    {
+        // uv_poll must be a naked pointer because the uv_close()
+        // call completes ansynchronosuly; deletion is performed
+        // in the close callback.
+        uv_poll = new uv_poll_t;
+
+        try {
+            // the dbus-cxx transport always opens a socket so we use the
+            // socket version of uv_poll_init. That is identical to the fd
+            // call on Linux but socket specific on Windows.
+            if (int r = uv_poll_init_socket(uv_default_loop(), uv_poll, connection->unix_fd()); r < 0) {
+                throw std::system_error(r, std::system_category(), "uv_poll_init_socket");
+            }
+
+            uv_poll->data = this;
+        }
+        catch (...) {
+            // despite the init failing, the loop retains a reference
+            // to the handle so it must be closed.
+            uv_close((uv_handle_t*)uv_poll, close_cb);
+
+            // Re-throw the exception
+            throw;
+        }
+
+        // Now the we have a valid poll handle, connect a signal to
+        // the "needs dispatch" event which indicates when the
+        // connection has data to write.
+        connection->signal_needs_dispatch().connect(
+            sigc::mem_fun(*this, &UVPollConnection::restart_writeable));
+
+        // Finally, we can start the handle for reading
+        restart();
+    }
+
+    UVPollConnection(const UVPollConnection &) = delete;
+    UVPollConnection &operator=(const UVPollConnection &) = delete;
+
+    UVPollConnection(UVPollConnection &&other) {
+        uv_poll = other.uv_poll;
+        other.uv_poll = nullptr;
+        connection = std::move(other.connection);
+    }
+
+    virtual ~UVPollConnection()
+    {
+        // ensure the poll object is stopped so it doesn't try to
+        // access the callback that is about to be destroyed
+        uv_poll_stop(uv_poll);
+
+        // zero out the reference for good measure
+        uv_poll->data = nullptr;
+
+        // Note: libuv owns the uv_poll allocation until the close
+        // callback completes.
+        uv_close((uv_handle_t*)uv_poll, close_cb);
+    }
+
+    void restart() { uv_poll_start(uv_poll, UV_READABLE, poll_cb); }
+
+    void restart_writeable() { uv_poll_start(uv_poll, UV_READABLE | UV_WRITABLE, poll_cb); }
+
+    std::shared_ptr<DBus::Connection> connection;
+
+private:
+    uv_poll_t* uv_poll = nullptr;
+};
+} // namespace
+
+
+void
 poll_cb(uv_poll_t* h, int status, int event)
 {
+    auto uvpc = static_cast<UVPollConnection*>(h->data);
+
     if (status == -EBADF) {
         // "bad file descrioptior" indicates the FD was a pipe
         // (FIFO) and the other end was closed
@@ -50,53 +131,20 @@ poll_cb(uv_poll_t* h, int status, int event)
         SIMPLELOGGER_DEBUG( LOGGER_NAME, "polled FD went bad, assmuming pipeline shutdown" );
     } else if (status < 0) {
         SIMPLELOGGER_ERROR( LOGGER_NAME, "poll_cb called with bad status: " << std::strerror(-status) << ", " << status);
-    } else if (event & (UV_READABLE | UV_WRITABLE)) {
-        auto conn = reinterpret_cast<DBus::Connection*>(h->data);
-        while(true) {
-            if(auto dispatch_status = conn->dispatch(); dispatch_status == DBus::DispatchStatus::COMPLETE ) {
-                break;
-            }
-        }
-    }
+    } else if (event & UV_WRITABLE) {
+         // if we were polling for write-ability, we need to restart
+         // the poll handle after dispatching to stop (the
+         // signal_needs_dispatch handler will restart for write)
+         while (uvpc->connection->dispatch() != DBus::DispatchStatus::COMPLETE) {
+         }
+         uvpc->restart();
+     } else if (event & UV_READABLE) {
+         // if there is no write-able event then there is no need to
+         // restart to poll handle
+         while (uvpc->connection->dispatch() != DBus::DispatchStatus::COMPLETE) {
+         }
+     }
 }
-
-namespace
-{
-class UVPollConnection
-{
-public:
-    UVPollConnection(std::shared_ptr<DBus::Connection> connection) : connection(connection)
-    {
-        uv_poll = new uv_poll_t;
-
-        // uv_poll must be a naked pointer because the final
-        // uv_close() call triggered in the destructor completes
-        // ansynchronosuly; deletion is performed in the close
-        // callback.
-        if (int r = uv_poll_init(uv_default_loop(), uv_poll, connection->unix_fd()); r < 0) {
-            throw std::system_error(r, std::system_category(), "uv_poll_init");
-        }
-
-        uv_poll->data = connection.get();
-
-        if (int r = uv_poll_start(uv_poll, UV_READABLE | UV_WRITABLE, poll_cb); r < 0) {
-            throw std::system_error(r, std::system_category(), "uv_poll_start");
-        }
-    }
-
-    virtual ~UVPollConnection()
-    {
-        uv_poll_stop(uv_poll);
-        // Note: libuv owns the uv_poll allocation until the close
-        // callback completes.
-        uv_close((uv_handle_t*)uv_poll, close_cb);
-    }
-
-private:
-    uv_poll_t* uv_poll = nullptr;
-    std::shared_ptr<DBus::Connection> connection;
-};
-} // namespace
 
 class UvDispatcher::priv_data {
 public:
@@ -141,7 +189,7 @@ bool UvDispatcher::add_connection( std::shared_ptr<DBus::Connection> connection 
         return true;
     }
     catch (std::system_error e) {
-        SIMPLELOGGER_ERROR( LOGGER_NAME, "connection failed: " << e.what() << ", " << e.code() );
+        SIMPLELOGGER_ERROR( LOGGER_NAME, "add_connection failed: " << e.what() << ", " << e.code() );
         return false;
     }
 }


### PR DESCRIPTION
These commits fix some errors in the UvDispatcher class, tidy up the pkgconfig usage in the libuv integration, and add a unit test.

The primary issues fixed are: 
- leaks when libuv calls failed during creation of the dispatcher object
- 100% CPU usage when the socket for DBus data was writeable
