### PR TITLE
Support for STRUCT DBus type and check for empty fdsToRead

### DIFF
--- a/dbus-cxx/signature.h
+++ b/dbus-cxx/signature.h
@@ -16,6 +16,7 @@
 #include <string>
 #include <vector>
 #include <stack>
+
 #include "enums.h"
 
 #ifndef DBUSCXX_SIGNATURE_H
@@ -48,17 +49,23 @@ namespace priv {
 /**
  * Represents a single entry in our graph of the signature
  */
-class SignatureNode {
+class SignatureNode
+{
 public:
-    SignatureNode( DataType d ) :
-        m_dataType( d ),
-        m_next( nullptr ),
-        m_sub( nullptr ) {}
+    typedef std::shared_ptr<SignatureNode> SignatureNodePointer;
+
+    SignatureNode(DataType data_type)
+    :    m_dataType(data_type),
+        m_next(),
+        m_sub()
+    {
+    }
 
     DataType m_dataType;
-    std::shared_ptr<priv::SignatureNode> m_next;
-    std::shared_ptr<priv::SignatureNode> m_sub;
+    SignatureNodePointer m_next;
+    SignatureNodePointer m_sub;
 };
+
 }
 
 class FileDescriptor;
@@ -71,9 +78,9 @@ template<typename... T> class MultipleReturn;
  *
  * @author Rick L Vinyard Jr <rvinyard@cs.nmsu.edu>
  */
-class Signature {
+class Signature
+{
 public:
-
     typedef SignatureIterator iterator;
 
     typedef const SignatureIterator const_iterator;
@@ -131,14 +138,21 @@ public:
 private:
     void initialize();
 
-    std::shared_ptr<priv::SignatureNode> create_signature_tree( std::string::const_iterator* it,
-        std::stack<ContainerType>* container_stack,
-        bool* ok );
+    typedef priv::SignatureNode::SignatureNodePointer SignatureNodePointer;
 
-    void print_node( std::ostream* stream, priv::SignatureNode* node, int spaces ) const;
+    SignatureNodePointer create_signature_tree(
+        std::string::const_iterator& itr,
+        std::stack<ContainerType>* container_stack,
+        bool& ok);
+
+    void print_node(
+        std::ostream* stream,
+        priv::SignatureNode* node,
+        int spaces) const;
 
 private:
     class priv_data;
+
 
     std::shared_ptr<priv_data> m_priv;
 };

--- a/dbus-cxx/signatureiterator.cpp
+++ b/dbus-cxx/signatureiterator.cpp
@@ -174,6 +174,11 @@ std::string SignatureIterator::iterate_over_subsig( std::shared_ptr<priv::Signat
         return "";
     }
 
+    if ( start->m_dataType == DataType::STRUCT )
+    {
+        retval += "(";
+    }
+
     if( start->m_dataType == DataType::DICT_ENTRY ) {
         retval += "{";
     }
@@ -189,6 +194,11 @@ std::string SignatureIterator::iterate_over_subsig( std::shared_ptr<priv::Signat
         }
 
         retval += iterate_over_subsig( current->m_sub );
+    }
+
+    if ( start->m_dataType == DataType::STRUCT )
+    {
+        retval += ")";
     }
 
     if( start->m_dataType == DataType::DICT_ENTRY ) {

--- a/dbus-cxx/signatureiterator.cpp
+++ b/dbus-cxx/signatureiterator.cpp
@@ -158,14 +158,15 @@ std::string SignatureIterator::iterate_over(
         }
         else
         {
-            TypeInfo ti(
-                current->m_dataType);
+            char dbus_char =
+                TypeInfo(current->m_dataType).to_dbus_char();
 
-            char dbusChar =
-                ti.to_dbus_char();
+            signature += dbus_char;
 
-            if (dbusChar)
-                signature += dbusChar;
+            if ( current->m_dataType == DataType::ARRAY )
+            {
+                signature += iterate_over(current->m_sub);
+            }
         }
     }
 

--- a/dbus-cxx/signatureiterator.h
+++ b/dbus-cxx/signatureiterator.h
@@ -109,7 +109,7 @@ public:
 
 private:
 
-    std::string iterate_over_subsig( std::shared_ptr<priv::SignatureNode> start ) const;
+    std::string iterate_over( std::shared_ptr<priv::SignatureNode> start ) const;
 
 private:
     class priv_data;

--- a/dbus-cxx/standalonedispatcher.cpp
+++ b/dbus-cxx/standalonedispatcher.cpp
@@ -151,7 +151,7 @@ void StandaloneDispatcher::dispatch_thread_main() {
             DBus::priv::wait_for_fd_activity( fds, -1 );
         std::vector<int> fdsToRead = std::get<2>( fdResponse );
 
-        if( fdsToRead[ 0 ] == m_priv->process_fd[ 1 ] ) {
+        if( !fdsToRead.empty() && fdsToRead[ 0 ] == m_priv->process_fd[ 1 ] ) {
             char discard;
             if( read( m_priv->process_fd[ 1 ], &discard, sizeof( char ) ) < 0 ){
                 SIMPLELOGGER_DEBUG( LOGGER_NAME, "Failure reading from dispatch thread process_fd: "

--- a/dbus-cxx/variantiterator.cpp
+++ b/dbus-cxx/variantiterator.cpp
@@ -176,6 +176,11 @@ bool VariantIterator::is_dict() const {
     return this->is_array() && this->element_type() == DataType::DICT_ENTRY;
 }
 
+bool VariantIterator::is_struct() const
+{
+    return arg_type() == DataType::STRUCT;
+}
+
 VariantIterator::operator bool() {
     // TODO check for invalid
     switch( this->arg_type() ) {

--- a/dbus-cxx/variantiterator.h
+++ b/dbus-cxx/variantiterator.h
@@ -115,7 +115,9 @@ public:
     operator std::tuple<T...>() {
         std::tuple<T...> tup;
 
-        VariantIterator subiter = this->recurse();
+        VariantIterator subiter =
+            (is_struct() ? recurse() : *this);
+
         std::apply( [subiter]( auto&& ...arg ) mutable {
             ( subiter >> ... >> arg );
         },
@@ -182,6 +184,9 @@ public:
 
     /** True if the iterator points to a dictionary */
     bool is_dict() const;
+
+    /** True if the iterator points to a struct */
+    bool is_struct() const;
 
 private:
     class priv_data;

--- a/unit-tests/signaturetests.cpp
+++ b/unit-tests/signaturetests.cpp
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later OR BSD-3-Clause
-// SPDX-License-Identifier: LGPL-3.0-or-later OR BSD-3-Clause
 /***************************************************************************
  *   Copyright (C) 2020 by Robert Middleton                                *
  *   robert.middleton@rm5248.com                                           *
@@ -37,10 +36,10 @@ bool signature_iterate_int32() {
 
     TEST_EQUALS_RET_FAIL( it.type(), DBus::DataType::INT32 );
 
-	// Check the output signature is the same as the input
-	TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
+    // Check the output signature is the same as the input
+    TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
 
-	return true;
+    return true;
 }
 
 bool signature_iterate_arrayint() {
@@ -58,9 +57,9 @@ bool signature_iterate_arrayint() {
     TEST_EQUALS_RET_FAIL( it.type(), DBus::DataType::INVALID );
 
     // Check the output signature is the same as the input
-	TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
+    TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
 
-	return true;
+    return true;
 }
 
 bool signature_iterate_arrayint2() {
@@ -76,9 +75,9 @@ bool signature_iterate_arrayint2() {
     TEST_EQUALS_RET_FAIL( subit.type(), DBus::DataType::INVALID );
 
     // Check the output signature is the same as the input
-	TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
+    TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
 
-	return true;
+    return true;
 }
 
 bool signature_iterate_nested_array() {
@@ -98,9 +97,9 @@ bool signature_iterate_nested_array() {
     TEST_EQUALS_RET_FAIL( subit2.type(), DBus::DataType::INVALID );
 
     // Check the output signature is the same as the input
-	TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
+    TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
 
-	return true;
+    return true;
 }
 
 bool signature_iterate_multiple_types() {
@@ -117,31 +116,44 @@ bool signature_iterate_multiple_types() {
     TEST_EQUALS_RET_FAIL( it.type(), DBus::DataType::BOOLEAN );
 
     // Check the output signature is the same as the input
-	TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
+    TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
 
-	return true;
+    return true;
 }
 
 bool signature_iterate_dictionary() {
-    DBus::Signature sig( "a{yv}" );
+    DBus::Signature sig( "a{yv}ii" );
 
     DBus::SignatureIterator it = sig.begin();
+
     TEST_EQUALS_RET_FAIL( it.is_dict(), true );
+    TEST_EQUALS_RET_FAIL(it.type(), DBus::DataType::ARRAY);
 
     DBus::SignatureIterator subit = it.recurse();
     TEST_EQUALS_RET_FAIL( subit.type(), DBus::DataType::DICT_ENTRY );
 
     DBus::SignatureIterator subsubit = subit.recurse();
     TEST_EQUALS_RET_FAIL( subsubit.type(), DBus::DataType::BYTE );
+
     subsubit.next();
     TEST_EQUALS_RET_FAIL( subsubit.type(), DBus::DataType::VARIANT );
+
     subsubit.next();
     TEST_EQUALS_RET_FAIL( subsubit.type(), DBus::DataType::INVALID );
 
-    // Check the output signature is the same as the input
-	TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
+    it.next();
+    TEST_EQUALS_RET_FAIL(it.type(), DBus::DataType::INT32);
 
-	return true;
+    it.next();
+    TEST_EQUALS_RET_FAIL(it.type(), DBus::DataType::INT32);
+
+    it.next();
+    TEST_EQUALS_RET_FAIL(it.type(), DBus::DataType::INVALID);
+
+    // Check the output signature is the same as the input
+    TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
+
+    return true;
 }
 
 bool signature_iterate_struct() {
@@ -163,9 +175,9 @@ bool signature_iterate_struct() {
     TEST_EQUALS_RET_FAIL( subit.type(), DBus::DataType::INVALID );
 
     // Check the output signature is the same as the input
-	TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
+    TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
 
-	return true;
+    return true;
 }
 
 bool signature_iterate_nested_with_more_data() {
@@ -182,9 +194,9 @@ bool signature_iterate_nested_with_more_data() {
     TEST_EQUALS_RET_FAIL( it.type(), DBus::DataType::INVALID );
 
     // Check the output signature is the same as the input
-	TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
+    TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
 
-	return true;
+    return true;
 }
 
 bool signature_iterate_dict_and_data() {
@@ -193,6 +205,9 @@ bool signature_iterate_dict_and_data() {
     DBus::SignatureIterator it = sig.begin();
 
     TEST_EQUALS_RET_FAIL( it.type(), DBus::DataType::ARRAY );
+
+    DBus::SignatureIterator subit = it.recurse();
+
     it.next();
     TEST_EQUALS_RET_FAIL( it.type(), DBus::DataType::INT32 );
     it.next();
@@ -200,10 +215,13 @@ bool signature_iterate_dict_and_data() {
     it.next();
     TEST_EQUALS_RET_FAIL( it.type(), DBus::DataType::INVALID );
 
-	// Check the output signature is the same as the input
-	TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
+    // Check the output signature is the same as the input
+    std::string test =
+        sig.begin().signature();
 
-	return true;
+    TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
+
+    return true;
 }
 
 bool signature_iterate_struct_and_data() {
@@ -219,10 +237,10 @@ bool signature_iterate_struct_and_data() {
     it.next();
     TEST_EQUALS_RET_FAIL( it.type(), DBus::DataType::INVALID );
 
-	// Check the output signature is the same as the input
-	TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
+    // Check the output signature is the same as the input
+    TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
 
-	return true;
+    return true;
 }
 
 bool signature_unbalanced_struct() {
@@ -234,9 +252,11 @@ bool signature_unbalanced_struct() {
 }
 
 bool signature_iterate_nested_struct() {
-    DBus::Signature sig( "(i(id))" );
+    DBus::Signature signature( "(i(id)ss)" );
 
-    DBus::SignatureIterator it = sig.begin();
+    TEST_EQUALS_RET_FAIL(signature.is_valid(), true);
+
+    DBus::SignatureIterator it = signature.begin();
 
     TEST_EQUALS_RET_FAIL( it.type(), DBus::DataType::STRUCT );
 
@@ -253,31 +273,62 @@ bool signature_iterate_nested_struct() {
     TEST_EQUALS_RET_FAIL( subit2.type(), DBus::DataType::INVALID );
 
     subit.next();
+    TEST_EQUALS_RET_FAIL( subit.type(), DBus::DataType::STRING);
+
+    subit.next();
+    TEST_EQUALS_RET_FAIL( subit.type(), DBus::DataType::STRING);
+
+    subit.next();
     TEST_EQUALS_RET_FAIL( subit.type(), DBus::DataType::INVALID );
 
     it.next();
-    TEST_EQUALS_RET_FAIL( it.type(), DBus::DataType::INVALID );
+    TEST_EQUALS_RET_FAIL( it.type(), DBus::DataType::INVALID);
 
-	// Check the output signature is the same as the input
-	TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
+    // Check the output signature is the same as the input
+    TEST_EQUALS_RET_FAIL(signature.str(), signature.begin().signature());
 
     return true;
 }
 
-bool signature_single_bool() {
+bool signature_iterate_nested_dict()
+{
+    DBus::Signature sig( "a{b{bs}}ix" );
+
+    DBus::SignatureIterator it = sig.begin();
+
+    TEST_EQUALS_RET_FAIL( it.type(), DBus::DataType::ARRAY );
+
+    DBus::SignatureIterator subit = it.recurse();
+
+    it.next();
+    TEST_EQUALS_RET_FAIL( it.type(), DBus::DataType::INT32 );
+    it.next();
+    TEST_EQUALS_RET_FAIL( it.type(), DBus::DataType::INT64 );
+    it.next();
+    TEST_EQUALS_RET_FAIL( it.type(), DBus::DataType::INVALID );
+
+    // Check the output signature is the same as the input
+    TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
+
+    return true;
+}
+
+bool signature_single_bool()
+{
     DBus::Signature sig( "b" );
 
     DBus::SignatureIterator it = sig.begin();
 
     TEST_EQUALS_RET_FAIL( it.type(), DBus::DataType::BOOLEAN );
 
-	// Check the output signature is the same as the input
-	TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
+    // Check the output signature is the same as the input
+    TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
 
-	return true;
+    return true;
 }
 
-bool signature_create_from_struct_in_array() {
+bool signature_create_from_struct_in_array()
+{
     std::vector<std::tuple<int32_t, uint64_t>> vector_type;
 
     std::string sig_output = DBus::signature( vector_type );
@@ -285,7 +336,8 @@ bool signature_create_from_struct_in_array() {
     return sig_output == "a(it)";
 }
 
-bool signature_single_type1() {
+bool signature_single_type1()
+{
     DBus::Signature sig( "i" );
 
     TEST_EQUALS_RET_FAIL( sig.is_singleton(), true );
@@ -293,7 +345,8 @@ bool signature_single_type1() {
     return true;
 }
 
-bool signature_single_type2() {
+bool signature_single_type2()
+{
     DBus::Signature sig( "ai" );
 
     TEST_EQUALS_RET_FAIL( sig.is_singleton(), true );
@@ -301,18 +354,18 @@ bool signature_single_type2() {
     return true;
 }
 
-#define ADD_TEST(name) do{ if( test_name == STRINGIFY(name) ){ \
+#define ADD_TEST(name) do{ if( test_name == STRINGIFY(name) ) { \
             ret = signature_##name();\
         } \
     } while( 0 )
 
-int main( int argc, char** argv )
+int main(int argc, char** argv)
 {
-	if ( argc < 2 )
+    if ( argc < 2 )
         return 1;
 
     std::string test_name(argv[1]);
-    bool ret = true;
+    bool ret = false;
 
     ADD_TEST( create );
     ADD_TEST( iterate_arrayint );
@@ -325,7 +378,7 @@ int main( int argc, char** argv )
     ADD_TEST( iterate_dict_and_data );
     ADD_TEST( iterate_struct_and_data );
     ADD_TEST( iterate_nested_struct );
-
+    ADD_TEST( iterate_nested_dict );
     ADD_TEST( unbalanced_struct );
     ADD_TEST( single_bool );
 
@@ -333,6 +386,6 @@ int main( int argc, char** argv )
     ADD_TEST( single_type1 );
     ADD_TEST( single_type2 );
 
-	std::cout << "Test case \"" + test_name + "\" " + (ret ? "PASSED" : "FAIL") << std::endl;
+    std::cout << "Test case \"" + test_name + "\" " + (ret ? "PASSED" : "FAIL") << std::endl;
     return !ret;
 }

--- a/unit-tests/signaturetests.cpp
+++ b/unit-tests/signaturetests.cpp
@@ -37,7 +37,10 @@ bool signature_iterate_int32() {
 
     TEST_EQUALS_RET_FAIL( it.type(), DBus::DataType::INT32 );
 
-    return true;
+	// Check the output signature is the same as the input
+	TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
+
+	return true;
 }
 
 bool signature_iterate_arrayint() {
@@ -54,7 +57,10 @@ bool signature_iterate_arrayint() {
 
     TEST_EQUALS_RET_FAIL( it.type(), DBus::DataType::INVALID );
 
-    return true;
+    // Check the output signature is the same as the input
+	TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
+
+	return true;
 }
 
 bool signature_iterate_arrayint2() {
@@ -69,7 +75,10 @@ bool signature_iterate_arrayint2() {
 
     TEST_EQUALS_RET_FAIL( subit.type(), DBus::DataType::INVALID );
 
-    return true;
+    // Check the output signature is the same as the input
+	TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
+
+	return true;
 }
 
 bool signature_iterate_nested_array() {
@@ -88,7 +97,10 @@ bool signature_iterate_nested_array() {
 
     TEST_EQUALS_RET_FAIL( subit2.type(), DBus::DataType::INVALID );
 
-    return true;
+    // Check the output signature is the same as the input
+	TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
+
+	return true;
 }
 
 bool signature_iterate_multiple_types() {
@@ -104,7 +116,10 @@ bool signature_iterate_multiple_types() {
     it.next();
     TEST_EQUALS_RET_FAIL( it.type(), DBus::DataType::BOOLEAN );
 
-    return true;
+    // Check the output signature is the same as the input
+	TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
+
+	return true;
 }
 
 bool signature_iterate_dictionary() {
@@ -123,7 +138,10 @@ bool signature_iterate_dictionary() {
     subsubit.next();
     TEST_EQUALS_RET_FAIL( subsubit.type(), DBus::DataType::INVALID );
 
-    return true;
+    // Check the output signature is the same as the input
+	TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
+
+	return true;
 }
 
 bool signature_iterate_struct() {
@@ -144,7 +162,10 @@ bool signature_iterate_struct() {
     subit.next();
     TEST_EQUALS_RET_FAIL( subit.type(), DBus::DataType::INVALID );
 
-    return true;
+    // Check the output signature is the same as the input
+	TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
+
+	return true;
 }
 
 bool signature_iterate_nested_with_more_data() {
@@ -160,7 +181,10 @@ bool signature_iterate_nested_with_more_data() {
     it.next();
     TEST_EQUALS_RET_FAIL( it.type(), DBus::DataType::INVALID );
 
-    return true;
+    // Check the output signature is the same as the input
+	TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
+
+	return true;
 }
 
 bool signature_iterate_dict_and_data() {
@@ -176,7 +200,10 @@ bool signature_iterate_dict_and_data() {
     it.next();
     TEST_EQUALS_RET_FAIL( it.type(), DBus::DataType::INVALID );
 
-    return true;
+	// Check the output signature is the same as the input
+	TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
+
+	return true;
 }
 
 bool signature_iterate_struct_and_data() {
@@ -192,7 +219,10 @@ bool signature_iterate_struct_and_data() {
     it.next();
     TEST_EQUALS_RET_FAIL( it.type(), DBus::DataType::INVALID );
 
-    return true;
+	// Check the output signature is the same as the input
+	TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
+
+	return true;
 }
 
 bool signature_unbalanced_struct() {
@@ -228,6 +258,9 @@ bool signature_iterate_nested_struct() {
     it.next();
     TEST_EQUALS_RET_FAIL( it.type(), DBus::DataType::INVALID );
 
+	// Check the output signature is the same as the input
+	TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
+
     return true;
 }
 
@@ -238,7 +271,10 @@ bool signature_single_bool() {
 
     TEST_EQUALS_RET_FAIL( it.type(), DBus::DataType::BOOLEAN );
 
-    return true;
+	// Check the output signature is the same as the input
+	TEST_EQUALS_RET_FAIL(sig.str(), sig.begin().signature());
+
+	return true;
 }
 
 bool signature_create_from_struct_in_array() {
@@ -270,13 +306,13 @@ bool signature_single_type2() {
         } \
     } while( 0 )
 
-int main( int argc, char** argv ) {
-    if( argc < 1 ) {
+int main( int argc, char** argv )
+{
+	if ( argc < 2 )
         return 1;
-    }
 
-    std::string test_name = argv[1];
-    bool ret = false;
+    std::string test_name(argv[1]);
+    bool ret = true;
 
     ADD_TEST( create );
     ADD_TEST( iterate_arrayint );
@@ -297,5 +333,6 @@ int main( int argc, char** argv ) {
     ADD_TEST( single_type1 );
     ADD_TEST( single_type2 );
 
+	std::cout << "Test case \"" + test_name + "\" " + (ret ? "PASSED" : "FAIL") << std::endl;
     return !ret;
 }


### PR DESCRIPTION
I have added support for the STRUCT D-Bus type, which are needed for some D-Bus interfaces for daemons on Ubuntu Linux and others.

Second, I have also added an extra check for fdsToRead is empty, which can be the case if the D-Bus daemon isn't yet running at boot time.