### PR TITLE
Fix signature parsing bug

### DIFF
--- a/dbus-cxx/signature.cpp
+++ b/dbus-cxx/signature.cpp
@@ -152,6 +152,8 @@ Signature::SignatureNodePointer Signature::create_signature_tree(
             } else if( currentTop == ContainerType::DICT_ENTRY &&
                 data_type == DataType::DICT_ENTRY ) {
                 return first;
+            } else if (currentTop == ContainerType::ARRAY) {
+                return first;
             } else {
                 ok = false;
                 return nullptr;

--- a/unit-tests/CMakeLists.txt
+++ b/unit-tests/CMakeLists.txt
@@ -249,6 +249,7 @@ add_test( NAME signature-create-from-struct-in-array COMMAND test-signature crea
 
 add_test( NAME signature-single-type1 COMMAND test-signature single_type1)
 add_test( NAME signature-single-type2 COMMAND test-signature single_type2)
+add_test( NAME signature-double-struct COMMAND test-signature double_struct)
 
 #
 # Validation tests - make sure that our validation routines work correctly

--- a/unit-tests/signaturetests.cpp
+++ b/unit-tests/signaturetests.cpp
@@ -350,6 +350,39 @@ bool signature_single_type2() {
     return true;
 }
 
+bool signature_double_struct() {
+    DBus::Signature sig( "(sa(us))" );
+
+    DBus::SignatureIterator it = sig.begin();
+
+    TEST_EQUALS_RET_FAIL( it.type(), DBus::DataType::STRUCT );
+    auto subit = it.recurse();
+    TEST_EQUALS_RET_FAIL( subit.type(), DBus::DataType::STRING );
+    subit.next();
+    TEST_EQUALS_RET_FAIL( subit.type(), DBus::DataType::ARRAY );
+    auto subit2 = subit.recurse();
+    TEST_EQUALS_RET_FAIL( subit2.type(), DBus::DataType::STRUCT );
+    auto subit3 = subit2.recurse();
+    TEST_EQUALS_RET_FAIL( subit3.type(), DBus::DataType::UINT32 );
+    subit3.next();
+    TEST_EQUALS_RET_FAIL( subit3.type(), DBus::DataType::STRING );
+    subit3.next();
+    TEST_EQUALS_RET_FAIL( subit3.type(), DBus::DataType::INVALID );
+
+    subit2.next();
+    TEST_EQUALS_RET_FAIL( subit2.type(), DBus::DataType::INVALID );
+
+    subit.next();
+    TEST_EQUALS_RET_FAIL( subit.type(), DBus::DataType::INVALID );
+
+    it.next();
+    TEST_EQUALS_RET_FAIL( it.type(), DBus::DataType::INVALID );
+    // Check the output signature is the same as the input
+    TEST_EQUALS_RET_FAIL( sig.str(), sig.begin().signature() );
+
+    return true;
+}
+
 #define ADD_TEST(name) do{ if( test_name == STRINGIFY(name) ){ \
             ret = signature_##name();\
         } \
@@ -381,6 +414,7 @@ int main( int argc, char** argv ) {
     ADD_TEST( create_from_struct_in_array );
     ADD_TEST( single_type1 );
     ADD_TEST( single_type2 );
+    ADD_TEST( double_struct );
 
     std::cout << "Test case \"" + test_name + "\" " + (ret ? "PASSED" : "FAIL") << std::endl;
     return !ret;


### PR DESCRIPTION
Fixes #157
It looks like the bug was an edge case when ending an array that contained a struct, which was immediately proceeded with another struct ending.

I added a test case for the signature described in #157 and made sure all 162 tests passed.

I couldn't come up with a nicer test name, so i just went with `double_struct`.