### PR TITLE
Fix compiler warnings about unused arguments

### DIFF
--- a/dbus-cxx/methodbase.h
+++ b/dbus-cxx/methodbase.h
@@ -61,7 +61,7 @@ public:
     virtual HandlerResult handle_call_message( std::shared_ptr<Connection> connection, std::shared_ptr<const CallMessage> message ) = 0;
 
     /** Returns a DBus XML description of this interface */
-    virtual std::string introspect( int space_depth = 0 ) const { return std::string(); };
+    virtual std::string introspect( int = 0 ) const { return std::string(); };
 
     std::string arg_name( size_t i ) const;
 

--- a/dbus-cxx/property.h
+++ b/dbus-cxx/property.h
@@ -65,7 +65,7 @@ public:
      */
     void set_value( Variant value );
 
-    virtual std::string introspect( int spaces ){ return std::string(); }
+    virtual std::string introspect( int ){ return std::string(); }
 
 private:
     void setInterface( Interface* );

--- a/dbus-cxx/signalbase.h
+++ b/dbus-cxx/signalbase.h
@@ -77,11 +77,11 @@ public:
     //      virtual std::shared_ptr<signal_base> clone() = 0;
 
     /** Returns a DBus XML description of this interface */
-    virtual std::string introspect( int space_depth = 0 ) const { return std::string(); }
+    virtual std::string introspect( int = 0 ) const { return std::string(); }
 
-    virtual std::string arg_name( size_t i ) { return std::string(); }
+    virtual std::string arg_name( size_t ) { return std::string(); }
 
-    virtual void set_arg_name( size_t i, const std::string& name ) { }
+    virtual void set_arg_name( size_t, const std::string& ) { }
 
 protected:
     bool handle_dbus_outgoing( std::shared_ptr<const Message> );


### PR DESCRIPTION
Pretty much everything that uses dbus-cxx spews out the following warnings:

```
In file included from /usr/include/dbus-cxx-2.0/dbus-cxx/signal.h:10,
                 from /usr/include/dbus-cxx-2.0/dbus-cxx/connection.h:11,
                 from /usr/include/dbus-cxx-2.0/dbus-cxx.h:17,
                 from ../main.cpp:2:
/usr/include/dbus-cxx-2.0/dbus-cxx/signalbase.h: In member function 'virtual std::string DBus::SignalBase::introspect(int) const':
/usr/include/dbus-cxx-2.0/dbus-cxx/signalbase.h:80:41: warning: unused parameter 'space_depth' [-Wunused-parameter]
   80 |     virtual std::string introspect( int space_depth = 0 ) const { return std::string(); }
      |                                     ~~~~^~~~~~~~~~~~~~~
/usr/include/dbus-cxx-2.0/dbus-cxx/signalbase.h: In member function 'virtual std::string DBus::SignalBase::arg_name(size_t)':
/usr/include/dbus-cxx-2.0/dbus-cxx/signalbase.h:82:42: warning: unused parameter 'i' [-Wunused-parameter]
   82 |     virtual std::string arg_name( size_t i ) { return std::string(); }
      |                                   ~~~~~~~^
/usr/include/dbus-cxx-2.0/dbus-cxx/signalbase.h: In member function 'virtual void DBus::SignalBase::set_arg_name(size_t, const std::string&)':
/usr/include/dbus-cxx-2.0/dbus-cxx/signalbase.h:84:39: warning: unused parameter 'i' [-Wunused-parameter]
   84 |     virtual void set_arg_name( size_t i, const std::string& name ) { }
      |                                ~~~~~~~^
/usr/include/dbus-cxx-2.0/dbus-cxx/signalbase.h:84:61: warning: unused parameter 'name' [-Wunused-parameter]
   84 |     virtual void set_arg_name( size_t i, const std::string& name ) { }
      |                                          ~~~~~~~~~~~~~~~~~~~^~~~
In file included from /usr/include/dbus-cxx-2.0/dbus-cxx/interface.h:10,
                 from /usr/include/dbus-cxx-2.0/dbus-cxx.h:23:
/usr/include/dbus-cxx-2.0/dbus-cxx/methodbase.h: In member function 'virtual std::string DBus::MethodBase::introspect(int) const':
/usr/include/dbus-cxx-2.0/dbus-cxx/methodbase.h:64:41: warning: unused parameter 'space_depth' [-Wunused-parameter]
   64 |     virtual std::string introspect( int space_depth = 0 ) const { return std::string(); };
      |                                     ~~~~^~~~~~~~~~~~~~~
In file included from /usr/include/dbus-cxx-2.0/dbus-cxx/interface.h:13:
/usr/include/dbus-cxx-2.0/dbus-cxx/property.h: In member function 'virtual std::string DBus::PropertyBase::introspect(int)':
/usr/include/dbus-cxx-2.0/dbus-cxx/property.h:68:41: warning: unused parameter 'spaces' [-Wunused-parameter]
   68 |     virtual std::string introspect( int spaces ){ return std::string(); }
      |                                     ~~~~^~~~~~
```

This PR fixes them. I have done little to no testing of this PR, but I believe that I haven't made any changes which would modify the functionality of dbus-cxx in any way. It shouldn't be possible for these changes to break anything.