### PR TITLE
doc: Remove env variables

### DIFF
--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -25,12 +25,6 @@
 
 PROJECT_NAME           = dbus-cxx
 
-# The PROJECT_NUMBER tag can be used to enter a project or revision number. This
-# could be handy for archiving the generated documentation or if some version
-# control system is used.
-
-PROJECT_NUMBER         = $(PACKAGE_VERSION)
-
 # With the PROJECT_LOGO tag one can specify an logo or icon that is included in
 # the documentation. The maximum height of the logo should not exceed 55 pixels
 # and the maximum width should not exceed 200 pixels. Doxygen will copy the logo
@@ -51,27 +45,6 @@ OUTPUT_DIRECTORY       = reference/
 # The default value is: YES.
 
 FULL_PATH_NAMES        = NO
-
-# The STRIP_FROM_PATH tag can be used to strip a user-defined part of the path.
-# Stripping is only done if one of the specified strings matches the left-hand
-# part of the path. The tag can be used to show relative paths in the file list.
-# If left blank the directory from which doxygen is run is used as the path to
-# strip.
-#
-# Note that you can specify absolute paths here, but also relative paths, which
-# will be relative from the directory where doxygen is started.
-# This tag requires that the tag FULL_PATH_NAMES is set to YES.
-
-STRIP_FROM_PATH        = $(SRCDIR)
-
-# The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
-# path mentioned in the documentation of a class, which tells the reader which
-# header file to include in order to use a class. If left blank only the name of
-# the header file containing the class definition is used. Otherwise one should
-# specify the list of include paths that are normally passed to the compiler
-# using the -I flag.
-
-STRIP_FROM_INC_PATH    = $(SRCDIR)
 
 # If the JAVADOC_AUTOBRIEF tag is set to YES then doxygen will interpret the
 # first line (until the first dot) of a Javadoc-style comment as the brief


### PR DESCRIPTION
This is more of an issue than a pull request, I wish to discuss these changes further before taking action.

The Doxyfile uses three environmental variables in it. I personally prefer to generate the Doxyfile from a Doxyfile.in file if I need to set some data in it during build configuration, the environment can be volatile and using it makes it harder to generate the documentation outside of the build system (by running `doxygen` manually).

But the main issue is that all three of these environment variables are unset during build, making them useless. I would have fixed this, but as I said, I don't like env variables in Doxyfile and I don't have extensive knowledge of the CMake build system (I can read it, but not write it).