### PR TITLE
Add .clang-format file

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,22 @@
+---
+IndentPPDirectives: BeforeHash
+IndentWidth: 4
+AccessModifierOffset: -4
+PointerAlignment: Left
+# NOTE: spaces in vec[ 5 ] aren't supported by clang-format
+SpacesInParentheses: true
+SpaceBeforeParens: Custom
+SpaceBeforeParensOptions:
+  AfterControlStatements: false
+  AfterForeachMacros: false
+  AfterFunctionDeclarationName: false
+  AfterFunctionDefinitionName: false
+  AfterIfMacros: false
+  AfterOverloadedOperator: false
+  BeforeNonEmptyParentheses: false
+AllowShortIfStatementsOnASingleLine: WithoutElse
+AllowShortEnumsOnASingleLine: false
+AllowShortLoopsOnASingleLine: true
+PackConstructorInitializers: CurrentLine
+AlwaysBreakTemplateDeclarations: Yes
+Standard: c++17


### PR DESCRIPTION
This should simplify the workflow for contributors and it should make the codebase more consistent.

I have handcrafted the `.clang-format` file to match the current coding style as closely as possible. There are still some differences though. I recommend reviewing these before merging this PR.

I have verified that this `.clang-format` file works with clang-format 14.0.0 (distributed by Debian stable).

I can recommend https://clang-format-configurator.site/ for tweaking the file.

Formatting can be manually disabled [like so](https://clang.llvm.org/docs/ClangFormatStyleOptions.html#disabling-formatting-on-a-piece-of-code):
```cpp
int formatted_code;
// clang-format off
    void    unformatted_code  ;
// clang-format on
void formatted_code_again;
```

Some differences I have noticed include
1. clang-format cannot add spaces inside the index operator, so `vec[ 5 ]` will become `vec[5]`
2. member initializer lists are aligned differently

   before:

   ```cpp
   template<typename Key, typename Value>
   Variant( const std::map<Key, Value>& map ) :
       m_currentType( DataType::ARRAY ),
       m_signature( DBus::signature( map ) ),
       m_dataAlignment( 4 ) {
       priv::VariantAppendIterator it( this );
   
       it << map;
   }
   ```

   after:

   ```cpp
   template <typename Key, typename Value>
   Variant( const std::map<Key, Value>& map )
       : m_currentType( DataType::ARRAY ),
         m_signature( DBus::signature( map ) ),
         m_dataAlignment( 4 ) {
       priv::VariantAppendIterator it( this );
   
       it << map;
   }
   ```

   This should be fixable, but IMO the new behavior is much more readable.
3. includes are sorted

   This might need to be disabled. I haven't yet tested formatting the entire codebase and testing whether it builds. Badly written header files which have hidden dependencies on other header files often break when they are reordered. I do not know whether dbus-cxx suffers from this problem.
4. clang-format tries harder to fit the code into a reasonable width

   A lot of code in dbus-cxx ignores maximum width requirements. clang-format doesn't, which is an advantage in my opinion.

If this change is to be fully adapted, the fact that pull requests should be clang-formatted should be documented somewhere (the best place would likely be the homepage, since this project has no dedicated CONTRIBUTING.md file). A GitHub Action verifying that pull requests are well formatted could be also added. I can add this to the PR if requested.