### PR TITLE
Add support for interactive authentication

### DIFF
--- a/dbus-cxx/callmessage.cpp
+++ b/dbus-cxx/callmessage.cpp
@@ -142,6 +142,19 @@ void CallMessage::set_no_reply( bool no_reply ) {
     set_flags( newflags );
 }
 
+void CallMessage::set_interactive_authentication( bool allow )
+{
+    uint8_t newflags = flags();
+
+    if( allow ) {
+        newflags |= DBUSCXX_MESSAGE_ALLOW_INTERACTIVE_AUTHORIZATION;
+    } else {
+        newflags &= ( ~DBUSCXX_MESSAGE_ALLOW_INTERACTIVE_AUTHORIZATION );
+    }
+
+    set_flags( newflags );
+}
+
 bool CallMessage::expects_reply() const {
     return flags() & DBUSCXX_MESSAGE_NO_REPLY_EXPECTED;
 }

--- a/dbus-cxx/callmessage.h
+++ b/dbus-cxx/callmessage.h
@@ -88,6 +88,8 @@ public:
 
     void set_no_reply( bool no_reply = true );
 
+    void set_interactive_authentication( bool allow );
+
     bool expects_reply() const;
 
     virtual MessageType type() const;

--- a/dbus-cxx/connection.cpp
+++ b/dbus-cxx/connection.cpp
@@ -406,8 +406,8 @@ Connection& Connection::operator <<( std::shared_ptr<const Message> msg ) {
     return *this;
 }
 
-std::shared_ptr<ReturnMessage> Connection::send_with_reply_blocking( std::shared_ptr<const CallMessage> message, int timeout_milliseconds ) {
-
+std::shared_ptr<ReturnMessage> Connection::send_with_reply_blocking_impl( std::shared_ptr<const CallMessage> message, int timeout_milliseconds, bool disable_timeout )
+{
     if( !this->is_valid() ) { throw ErrorDisconnected(); }
 
     if( !message ) { return std::shared_ptr<ReturnMessage>(); }
@@ -415,7 +415,7 @@ std::shared_ptr<ReturnMessage> Connection::send_with_reply_blocking( std::shared
     std::shared_ptr<ReturnMessage> retmsg;
     int msToWait = timeout_milliseconds;
 
-    if( msToWait == -1 ) {
+    if( !disable_timeout && msToWait == -1 ) {
         // Use a sane default value
         msToWait = 20000;
     }
@@ -440,13 +440,18 @@ std::shared_ptr<ReturnMessage> Connection::send_with_reply_blocking( std::shared
         fds.push_back( m_priv->m_transport->fd() );
 
         do {
-            std::tuple<bool, int, std::vector<int>, std::chrono::milliseconds> fdResponse =
-                DBus::priv::wait_for_fd_activity( fds, msToWait );
+            std::tuple<bool, int, std::vector<int>, std::chrono::milliseconds> fdResponse;
+            if ( disable_timeout ) {
+                fdResponse = DBus::priv::wait_for_fd_activity( fds, -1 );
+            }
+            else {
+                fdResponse = DBus::priv::wait_for_fd_activity( fds, msToWait );
 
-            msToWait -= std::get<3>( fdResponse ).count();
+                msToWait -= std::get<3>( fdResponse ).count();
 
-            if( msToWait <= 0 ) {
-                throw ErrorNoReply( "Did not receive a response in the alotted time" );
+                if( msToWait <= 0 ) {
+                    throw ErrorNoReply( "Did not receive a response in the alotted time" );
+                }
             }
 
             if( !m_priv->m_transport->is_valid() ) {
@@ -517,14 +522,22 @@ std::shared_ptr<ReturnMessage> Connection::send_with_reply_blocking( std::shared
              */
             std::chrono::time_point now = std::chrono::steady_clock::now();
             std::unique_lock<std::mutex> lock( ex->cv_lock );
-            bool status = ex->cv.wait_until( lock, now + std::chrono::milliseconds( msToWait ), [this, serial] {
+            bool status;
+            auto predicate = [this, serial] {
                 std::unique_lock<std::mutex> lock( m_priv->m_expectingResponsesLock );
                 std::map<uint32_t, std::shared_ptr<ExpectingResponse>>::iterator it =
                     m_priv->m_expectingResponses.find( serial );
 
                 // return false if the waiting should be continued
                 return ( *it ).second->reply.get() != nullptr;
-            } );
+            };
+            if ( disable_timeout ) {
+                ex->cv.wait( lock, predicate );
+                status = true;
+            }
+            else {
+                status = ex->cv.wait_until( lock, now + std::chrono::milliseconds( msToWait ), predicate );
+            }
             std::shared_ptr<ExpectingResponse> resp;
 
             {
@@ -562,6 +575,16 @@ std::shared_ptr<ReturnMessage> Connection::send_with_reply_blocking( std::shared
     }
 
     return retmsg;
+}
+
+std::shared_ptr<ReturnMessage> Connection::send_with_reply_blocking( std::shared_ptr<const CallMessage> message, int timeout_milliseconds )
+{
+    return this->send_with_reply_blocking_impl( std::move(message), timeout_milliseconds, false );
+}
+
+std::shared_ptr<ReturnMessage> Connection::send_with_reply_blocking_notimeout( std::shared_ptr<const CallMessage> message )
+{
+    return this->send_with_reply_blocking_impl( std::move(message), -1, true );
 }
 
 void Connection::flush() {

--- a/dbus-cxx/connection.h
+++ b/dbus-cxx/connection.h
@@ -195,10 +195,15 @@ public:
      * If a timeout is processed, this will throw ErrorNoReply
      *
      * @param msg The message to send
-     * @param timeout_milliseconds How long to wait for.  If -1, will wait the maximum time
+     * @param timeout_milliseconds How long to wait for. If -1, a "sane default value" is used.
      * @return The return message
      */
     std::shared_ptr<ReturnMessage> send_with_reply_blocking( std::shared_ptr<const CallMessage> msg, int timeout_milliseconds = -1 );
+
+    /**
+     * A timeout-less version of @ref send_with_reply_blocking().
+     */
+    std::shared_ptr<ReturnMessage> send_with_reply_blocking_notimeout( std::shared_ptr<const CallMessage> msg );
 
     /**
      * Flushes all data out to the bus.  This should generally
@@ -419,6 +424,8 @@ private:
     void process_single_message();
 
     void remove_invalid_threaddispatchers_and_associated_objects();
+
+    std::shared_ptr<ReturnMessage> send_with_reply_blocking_impl( std::shared_ptr<const CallMessage> msg, int timeout_milliseconds, bool disable_timeout );
 
     /**
      * Send an error back to the calling application based on HandlerResult.  No-op if the

--- a/dbus-cxx/error.h
+++ b/dbus-cxx/error.h
@@ -143,6 +143,19 @@ DBUSCXX_ERROR( ErrorAccessDenied, DBUSCXX_ERROR_ACCESS_DENIED );
 DBUSCXX_ERROR( ErrorAuthFailed, DBUSCXX_ERROR_AUTH_FAILED );
 
 /**
+ * @class ErrorInteractiveAuthorizationRequired
+ * @ingroup errors
+ *
+ * This error is caused attempting to call a D-Bus method which expects
+ * `ALLOW_INTERACTIVE_AUTHORIZATION` to be set when it isn't. See
+ * <https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-messages>.
+ *
+ * This flag can be enabled with @ref
+ * DBus::MethodProxyBase::enable_interactive_authorization().
+ */
+DBUSCXX_ERROR( ErrorInteractiveAuthorizationRequired, DBUSCXX_ERROR_INTERACTIVE_AUTHORIZATION_REQUIRED );
+
+/**
  * @class ErrorNoServer
  * @ingroup errors
  * @author Rick L Vinyard Jr <rvinyard@cs.nmsu.edu>

--- a/dbus-cxx/errormessage.cpp
+++ b/dbus-cxx/errormessage.cpp
@@ -122,6 +122,12 @@ void ErrorMessage::throw_error() {
     DBUS_ERROR_CHECK( DBUSCXX_ERROR_MATCH_RULE_NOT_FOUND, ErrorMatchRuleNotFound );
     DBUS_ERROR_CHECK( DBUSCXX_ERROR_MATCH_RULE_INVALID, ErrorMatchRuleInvalid );
 
+    if ( name() == DBUSCXX_ERROR_INTERACTIVE_AUTHORIZATION_REQUIRED )
+        throw ErrorInteractiveAuthorizationRequired(
+            message() + " (dbus-cxx developer note: Consider calling "
+            "enable_interactive_authorization() on the method proxy)"
+        );
+
     throw Error( name(), message() );
 }
 

--- a/dbus-cxx/interfaceproxy.cpp
+++ b/dbus-cxx/interfaceproxy.cpp
@@ -224,6 +224,12 @@ std::shared_ptr<const ReturnMessage> InterfaceProxy::call( std::shared_ptr<const
     return m_priv->m_object->call( call_message, timeout_milliseconds );
 }
 
+std::shared_ptr<const ReturnMessage> InterfaceProxy::call_notimeout( std::shared_ptr<const CallMessage> call_message ) const {
+    if( !m_priv->m_object ) { return std::shared_ptr<const ReturnMessage>(); }
+
+    return m_priv->m_object->call_notimeout( call_message );
+}
+
 //  std::shared_ptr<PendingCall> InterfaceProxy::call_async( std::shared_ptr<const CallMessage> call_message, int timeout_milliseconds ) const
 //  {
 //    if ( not m_priv->m_object ) return std::shared_ptr<PendingCall>();

--- a/dbus-cxx/interfaceproxy.h
+++ b/dbus-cxx/interfaceproxy.h
@@ -147,6 +147,8 @@ public:
 
     std::shared_ptr<const ReturnMessage> call( std::shared_ptr<const CallMessage>, int timeout_milliseconds = -1 ) const;
 
+    std::shared_ptr<const ReturnMessage> call_notimeout( std::shared_ptr<const CallMessage> ) const;
+
     //      std::shared_ptr<PendingCall> call_async( std::shared_ptr<const CallMessage>, int timeout_milliseconds=-1 ) const;
 
     template <class T_arg>

--- a/dbus-cxx/message.h
+++ b/dbus-cxx/message.h
@@ -18,8 +18,10 @@
 #ifndef DBUSCXX_MESSAGE_H
 #define DBUSCXX_MESSAGE_H
 
-#define DBUSCXX_MESSAGE_NO_REPLY_EXPECTED   0x01
-#define DBUSCXX_MESSAGE_NO_AUTO_START_FLAG  0x02
+#define DBUSCXX_MESSAGE_NO_REPLY_EXPECTED               0x01
+#define DBUSCXX_MESSAGE_NO_AUTO_START_FLAG              0x02
+// This is set in CallMessage only.
+#define DBUSCXX_MESSAGE_ALLOW_INTERACTIVE_AUTHORIZATION 0x04
 
 namespace DBus {
 class ReturnMessage;

--- a/dbus-cxx/methodproxybase.cpp
+++ b/dbus-cxx/methodproxybase.cpp
@@ -9,6 +9,8 @@
 #include "callmessage.h"
 #include "interfaceproxy.h"
 
+#include <limits>
+
 namespace DBus {
 
 class PendingCall;
@@ -18,10 +20,23 @@ class MethodProxyBase::priv_data {
 public:
     priv_data( const std::string& name ) :
         m_interface( nullptr ),
-        m_name( name ) {}
+        m_name( name ),
+        m_override_timeout( -1 ) {}
 
     InterfaceProxy* m_interface;
     const std::string m_name;
+    // Override the timeout of call() member function. This is used when
+    // interactive authorization is enabled.
+    // Possible values:
+    // -1: Interactive authorization is off, this variable should be
+    //     ignored and the timeout_milliseconds argument of call() is
+    //     respected.
+    //  0: Interactive authorization is on, unlimited timeout is set.
+    //     The timeout_milliseconds argument of call() is ignored.
+    // >0: Interactive authorization is on, timeout equal to
+    //     override_timeout is set. This timeout overrides the
+    //     timeout_milliseconds argument of call().
+    std::atomic<int> m_override_timeout;
 };
 
 
@@ -54,13 +69,41 @@ std::shared_ptr<CallMessage> DBus::MethodProxyBase::create_call_message() const 
 
     std::shared_ptr<CallMessage> cm = m_priv->m_interface->create_call_message( m_priv->m_name );
     cm->set_no_reply( false );
+    cm->set_interactive_authentication( m_priv->m_override_timeout.load() != -1 );
     return cm;
 }
 
 std::shared_ptr<const ReturnMessage> DBus::MethodProxyBase::call( std::shared_ptr<const CallMessage> call_message, int timeout_milliseconds ) const {
     if( !m_priv->m_interface ) { return std::shared_ptr<const ReturnMessage>(); }
 
-    return m_priv->m_interface->call( call_message, timeout_milliseconds );
+    int timeout = m_priv->m_override_timeout.load();
+    switch ( timeout ) {
+    case -1:
+        return m_priv->m_interface->call( call_message, timeout_milliseconds );
+    case 0:
+        return m_priv->m_interface->call_notimeout( call_message );
+    default:
+        return m_priv->m_interface->call( call_message, timeout );
+    }
+}
+
+void DBus::MethodProxyBase::enable_interactive_authorization( unsigned int timeout_milliseconds )
+{
+    constexpr auto int_max = std::numeric_limits<int>::max();
+
+    if ( timeout_milliseconds > int_max ) {
+        throw std::invalid_argument(
+            "DBus::MethodProxyBase::enable_interactive_authorization() received "
+            "too large timeout! Expected <=" + std::to_string( int_max ) + ", got " +
+            std::to_string( timeout_milliseconds ) + "!"
+        );
+    }
+    m_priv->m_override_timeout.store( static_cast<int>( timeout_milliseconds ) );
+}
+
+void DBus::MethodProxyBase::disable_interactive_authorization()
+{
+    m_priv->m_override_timeout.store( -1 );
 }
 
 //  std::shared_ptr<PendingCall> DBus::MethodProxyBase::call_async(std::shared_ptr<const CallMessage> call_message, int timeout_milliseconds) const

--- a/dbus-cxx/methodproxybase.h
+++ b/dbus-cxx/methodproxybase.h
@@ -58,6 +58,64 @@ public:
 
     std::shared_ptr<const ReturnMessage> call( std::shared_ptr<const CallMessage>, int timeout_milliseconds = -1 ) const;
 
+    /**
+     * Enable interactive authorization for method call.
+     *
+     * To quote the [D-Bus
+     * specification](https://dbus.freedesktop.org/doc/dbus-specification.html#message-protocol-messages):
+     *
+     * > This flag may be set on a method call message to inform the receiving side that
+     * > the caller is prepared to wait for interactive authorization, which might take
+     * > a considerable time to complete. For instance, if this flag is set, it would be
+     * > appropriate to query the user for passwords or confirmation via Polkit or a
+     * > similar framework.
+     * >
+     * > This flag is only useful when unprivileged code calls a more privileged method
+     * > call, and an authorization framework is deployed that allows possibly interactive
+     * > authorization. If no such framework is deployed it has no effect. This flag should
+     * > not be set by default by client implementations. If it is set, the caller should
+     * > also set a suitably long timeout on the method call to make sure the user
+     * > interaction may complete. This flag is only valid for method call messages, and
+     * > shall be ignored otherwise.
+     * >
+     * > If a this flag is not set on a method call, and a service determines that the
+     * > requested operation is not allowed without interactive authorization, but could
+     * > be allowed after successful interactive authorization, it may return the
+     * > @ref DBus::ErrorInteractiveAuthorizationRequired error.
+     * >
+     * > The absence of this flag does not guarantee that interactive authorization will
+     * > not be applied, since existing services that pre-date this flag might already use
+     * > interactive authorization. However, existing D-Bus APIs that will use interactive
+     * > authorization should document that the call may take longer than usual, and new
+     * > D-Bus APIs should avoid interactive authorization in the absence of this flag.
+     *
+     * Disabled by default.
+     *
+     * @note
+     * Any call messages created by @ref create_call_message() before this function is
+     * called will retain the old behavior. If that is not desirable, call @ref
+     * create_call_message() again after this function is called and use the new return
+     * value.
+     *
+     * @param timeout Timeout of the request in milliseconds. If set to zero, no timeout
+     *                is imposed. This timeout overrides the `timeout_milliseconds` argument
+     *                of @ref call() (used in @ref MethodProxy).
+     *
+     * @throws std::invalid_argument If `timeout_milliseconds` doesn't fit into a `signed int`.
+     */
+    void enable_interactive_authorization( unsigned int timeout_milliseconds = 0 );
+
+    /**
+     * Disable interactive authorization for method call.
+     *
+     * See @ref enable_interactive_authorization() for more info.
+     *
+     * If @ref enable_interactive_authorization() was called already, the timeout set by it
+     * is cleared by this function. The `timeout_milliseconds` argument of @ref call() will
+     * no longer be overriden.
+     */
+    void disable_interactive_authorization();
+
     //      std::shared_ptr<PendingCall> call_async( std::shared_ptr<const CallMessage>, int timeout_milliseconds=-1 ) const;
 
 private:

--- a/dbus-cxx/objectproxy.cpp
+++ b/dbus-cxx/objectproxy.cpp
@@ -276,6 +276,14 @@ std::shared_ptr<const ReturnMessage> ObjectProxy::call( std::shared_ptr<const Ca
     return conn->send_with_reply_blocking( call_message, timeout_milliseconds );
 }
 
+std::shared_ptr<const ReturnMessage> ObjectProxy::call_notimeout( std::shared_ptr<const CallMessage> call_message ) const {
+    std::shared_ptr<Connection> conn = m_priv->m_connection.lock();
+
+    if( !conn ) { return std::shared_ptr<ReturnMessage>(); }
+
+    return conn->send_with_reply_blocking_notimeout( call_message );
+}
+
 sigc::signal< void( std::shared_ptr<InterfaceProxy> )> ObjectProxy::signal_interface_added() {
     return m_priv->m_signal_interface_added;
 }

--- a/dbus-cxx/objectproxy.h
+++ b/dbus-cxx/objectproxy.h
@@ -127,6 +127,11 @@ public:
     std::shared_ptr<const ReturnMessage> call( std::shared_ptr<const CallMessage>, int timeout_milliseconds = -1 ) const;
 
     /**
+     * A timeout-less version of @ref call().
+     */
+    std::shared_ptr<const ReturnMessage> call_notimeout( std::shared_ptr<const CallMessage> ) const;
+
+    /**
      * Creates a proxy method with a signature based on the template parameters and adds it to the named interface
      * @return A smart pointer to the newly created method proxy
      * @param interface_name The name of the interface to add this proxy method to


### PR DESCRIPTION
This makes polkit-protected methods usable in dbus-cxx.

These methods usually need a special `ALLOW_INTERACTIVE_AUTHORIZATION` flag to be set in the method call message (this is further documented in the documentation of `DBus::MethodProxyBase::enable_interactive_authorization()` method I have added).

Example usage:

```cpp
#include <cassert>
#include <dbus-cxx.h>

int main()
{
    auto dispatcher = DBus::StandaloneDispatcher::create();
    assert(dispatcher);
    auto connection = dispatcher->create_connection(DBus::BusType::SYSTEM);
    assert(connection);
    auto proxy = connection->create_object_proxy("org.freedesktop.systemd1", "/org/freedesktop/systemd1");
    assert(proxy);

    auto reload_proxy = proxy->create_method<void()>("org.freedesktop.systemd1.Manager", "Reload");
    assert(reload_proxy);

    // Set a timeout of 25 seconds.
    reload_proxy->enable_interactive_authorization(25000);

    (*reload_proxy)();
}
```

# "Q&A"

1. Why are an extra state variable and two methods setting it (`enable_interactive_authorization()` and `disable_interactive_authorization()`) added to `MethodProxyBase` instead of making this a function argument?

   The `create_call_message()` and `call()` methods are already in use [in `MethodProxy`](https://github.com/dbus-cxx/dbus-cxx/blob/0285006ac71ba6b16d82a69d3927a85e1c104e4e/dbus-cxx/methodproxybase.h#L81-L169). `MethodProxy` classes are _template_ classes, so any modification to their body would be an ABI breaking change. I therefore had to think of an indirect solution (`enable_interactive_authorization()` and `disable_interactive_authorization()` which alter `create_call_message()` and `call()`).

   I made this an extra function everywhere else. Adding a function isn't a breaking change, so I was able to avoid this solution elsewhere.
2. Why bother with the fancy exception message in `dbus-cxx/errormessage.cpp`?

   I think that this is more user friendly than giving the user the raw error message. The raw `INTERACTIVE_AUTHORIZATION_REQUIRED` error message is cryptic for both users and developers, suggesting a solution to it right away will likely save people time debugging this.
3. Why add extra `_notimeout` functions? Can't a timeout of `-1` in already existing functions signify a lack of the timeout?

   The value of `-1` already has a meaning: it defaults to a "default sane value". This design is flawed (the [current default value of 20000](https://github.com/dbus-cxx/dbus-cxx/blob/0285006ac71ba6b16d82a69d3927a85e1c104e4e/dbus-cxx/connection.cpp#L418-L421) should have been the default argument in the first place), but changing it would again modify the already established behavior of the `call()` functions, thus making a breaking change.
4. Why does `DBus::MethodProxyBase::enable_interactive_authorization()` accept a mandatory timeout? Enabling interactive authorization and setting the operation timeout are two distinct operations. Shouldn't they be separate?

   One of the primary properties of an interactive authorization enabled method call is that it can take a long time (it finishes once the user enters a password and confirms it). There are several reasons why I chose to merge these two operations:

   1. The 20 second default timeout may be too limiting.
   2. The user may not be aware that there is a method call timeout or that it _should_ be overriden when interactive authentication is needed. Some of this confusion can be cleared with good documentation, but merging these two operations (enabling the interactive bit and overriding timeout) makes it much harder to be ignorant to the timeout.
   3. It lets me turn off the timeout by default (the `timeout_milliseconds` argument of `enable_interactive_authorization()` is currently set to 0 by default, signifying unlimited timeout). There are other ways to implement this, but this is one of the more explicit ones (in this case the more explicit the better).
   4. There isn't currently a way to override the timeout of a `MethodProxy`. There are other ways to implement this, the simplest being simply providing an `override_timeout()` function.

---

I've also got some comments:

- The documentation could use some cleaning up. I can help with that. I have already made several PRs improving Doxygen itself, I can also look at the documentation contents.

  For example, the documentation of `DBus::Connection::send_with_reply_blocking()` says that the value of `-1` makes the function "wait the maximum time". This is a lie (as shown above).
- Maintaining API/ABI compatibility was a priority for me when making this PR. I believe I have achieved this goal, but I might have overlooked something. Please review these changes before merging.
- My `_notimeout` changes were tested on some polkit-protected parts of the systemd interface. Even though I have implemented changes disabling dbus-cxx' timeout, I am still receiving timeouts after 25 seconds. I believe that this is a timeout imposed by systemd itself, but if not, additional changes to dbus-cxx may be needed to give the user enough time to enter the password.
- I have added a `ErrorInteractiveAuthorizationRequired` exception. Its D-Bus string representation, `DBUSCXX_ERROR_INTERACTIVE_AUTHORIZATION_REQUIRED` was already present in `error.h`, but this macro wasn't used anywhere.