### PR TITLE
fix: enable search engine in doxygen

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -342,7 +342,7 @@ GENERATE_TREEVIEW      = YES
 # The default value is: YES.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-SEARCHENGINE           = NO
+SEARCHENGINE           = YES
 
 #---------------------------------------------------------------------------
 # Configuration options related to the LaTeX output


### PR DESCRIPTION
This enables a javascript based searchbar in the doxygen output